### PR TITLE
Add move highlighting

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -96,6 +96,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2376,6 +2377,7 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2393,6 +2395,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2404,6 +2407,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2483,6 +2487,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2806,6 +2811,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2961,6 +2967,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3033,6 +3040,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -3159,6 +3167,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3559,6 +3568,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3806,6 +3816,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4981,6 +4992,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5034,6 +5046,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5086,6 +5099,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5098,6 +5112,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5414,7 +5429,8 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -5523,6 +5539,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5675,6 +5692,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/src/components/ChessBoard.tsx
+++ b/frontend/src/components/ChessBoard.tsx
@@ -17,6 +17,7 @@ interface ChessBoardProps {
   onTileClick: (square: string) => void;
   HORIZONTAL: string[];
   VERTICAL: string[];
+  lastMove?: { from?: string; to?: string } | null;
 }
 
 export function ChessBoard({
@@ -29,6 +30,7 @@ export function ChessBoard({
   onTileClick,
   HORIZONTAL,
   VERTICAL,
+  lastMove,
 }: ChessBoardProps) {
   const [size, setSize] = useState(320);
   const labelSize = 18;
@@ -103,6 +105,7 @@ export function ChessBoard({
               const isLight = (rowIdx + colIdx) % 2 === 0;
               const isSelected = selectedSquare === squareName;
               const isHighlight = validMoves.includes(squareName);
+              const isLastMoveSquare = lastMove && (squareName === lastMove.from || squareName === lastMove.to);
 
               return (
                 <button
@@ -115,6 +118,7 @@ export function ChessBoard({
                     ${isLight ? "bg-[var(--board-light)]" : "bg-[var(--board-dark)]"}
                     ${isSelected ? "bg-[#CDD26A] ring-2 ring-inset ring-primary/40" : ""}
                     ${isHighlight && piece ? "ring-2 ring-inset ring-[var(--board-highlight)]" : ""}
+                    ${isLastMoveSquare ? "bg-[#BACA44]/60" : ""}
                   `}
                   style={{ gridColumn: colIdx + 2, gridRow: rowIdx + 1, width: tileSize, height: tileSize }}
                 >

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -396,8 +396,7 @@ export function useGame(options?: UseGameOptions) {
             const m = msg as AIMoveMessage;
             const aiColor = playerColorRef.current === "white" ? "b" : "w";
             setAiThinking(false);
-            const moveData = m.move || {};
-            setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: moveData.from, to: moveData.to }]);
+            setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: m.fromSquare, to: m.toSquare }]);
             if (m.updatedFen) {
               try {
                 chess.load(m.updatedFen);
@@ -416,8 +415,7 @@ export function useGame(options?: UseGameOptions) {
             const aiColor = playerColorRef.current === "white" ? "b" : "w";
             setAiThinking(false);
             if (m.captured) {
-              const moveData = m.move || {};
-              setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: moveData.from, to: moveData.to }]);
+              setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: m.aiFromSquare, to: m.aiToSquare }]);
             }
             if (m.updatedFen) {
               try {
@@ -530,8 +528,7 @@ export function useGame(options?: UseGameOptions) {
             const m = msg as AIMoveMessage;
             const aiColor = playerColorRef.current === "white" ? "b" : "w";
             setAiThinking(false);
-            const moveData = m.move || {};
-            setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: moveData.from, to: moveData.to }]);
+            setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: m.fromSquare, to: m.toSquare }]);
             if (m.updatedFen) {
               try {
                 chess.load(m.updatedFen);
@@ -550,8 +547,7 @@ export function useGame(options?: UseGameOptions) {
             const aiColor = playerColorRef.current === "white" ? "b" : "w";
             setAiThinking(false);
             if (m.captured) {
-              const moveData = m.move || {};
-              setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: moveData.from, to: moveData.to }]);
+              setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: m.aiFromSquare, to: m.aiToSquare }]);
             }
             if (m.updatedFen) {
               try {

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -77,7 +77,7 @@ export function useGame(options?: UseGameOptions) {
   const [playerColor, setPlayerColor] = useState<PlayerColor>(initialColor ?? initialGameState?.playerColor ?? "white");
 
   const [fenInput, setFenInput] = useState("");
-  const [moveHistory, setMoveHistory] = useState<Array<{ captured?: string; color: "w" | "b" }>>([]);
+  const [moveHistory, setMoveHistory] = useState<Array<{ captured?: string; color: "w" | "b"; from?: string; to?: string }>>([]);
   const isAdmin = typeof window !== "undefined" && window.location.pathname === "/admin";
 
   const wsRef = useRef<WebSocket | null>(null);
@@ -121,7 +121,8 @@ export function useGame(options?: UseGameOptions) {
         if (!res.ok) throw new Error(`Backend error: ${res.status}`);
         const data = await res.json();
         if (data.updated_fen) {
-          setMoveHistory((prev) => [...prev, { captured: data.captured, color: aiTurn }]);
+          const moveData = data.move || {};
+          setMoveHistory((prev) => [...prev, { captured: data.captured, color: aiTurn, from: moveData.from, to: moveData.to }]);
           chess.load(data.updated_fen);
           setBoardState(chess.board());
           setPlayerHasMoved(true);
@@ -220,11 +221,13 @@ export function useGame(options?: UseGameOptions) {
       setPendingPromotionFrom(null);
       setPendingPromotionTo(null);
       if (!move) return;
+      const from = (move as { from: string }).from;
+      const to = (move as { to: string }).to;
+      const captured = (move as { captured?: string }).captured;
       setBoardState(chess.board());
       setSelectedSquare(null);
       setValidMoves([]);
-      const captured = (move as { captured?: string }).captured;
-      setMoveHistory((prev) => [...prev, { captured, color: playerTurn }]);
+      setMoveHistory((prev) => [...prev, { captured, color: playerTurn, from, to }]);
       if (!playerHasMoved) setPlayerHasMoved(true);
       playMoveSound();
       if (chess.isGameOver()) {
@@ -232,8 +235,6 @@ export function useGame(options?: UseGameOptions) {
         return;
       }
       const fen = chess.fen();
-      const from = (move as { from: string }).from;
-      const to = (move as { to: string }).to;
       sendPromotionMove(fen, from, to, piece, captured);
     },
     [chess, pendingPromotionFrom, pendingPromotionTo, playerHasMoved, openEndgame, sendPromotionMove, playerTurn]
@@ -299,9 +300,12 @@ export function useGame(options?: UseGameOptions) {
       setSelectedSquare(null);
       setValidMoves([]);
       if (!move) return;
-      setBoardState(chess.board());
+      const from = (move as { from: string }).from;
+      const to = (move as { to: string }).to;
       const captured = (move as { captured?: string }).captured;
-      setMoveHistory((prev) => [...prev, { captured, color: playerTurn }]);
+      const san = (move as { san: string }).san;
+      setBoardState(chess.board());
+      setMoveHistory((prev) => [...prev, { captured, color: playerTurn, from, to }]);
       if (!playerHasMoved) setPlayerHasMoved(true);
       playMoveSound();
       if (chess.isGameOver()) {
@@ -309,9 +313,6 @@ export function useGame(options?: UseGameOptions) {
         return;
       }
       const fen = chess.fen();
-      const from = (move as { from: string }).from;
-      const to = (move as { to: string }).to;
-      const san = (move as { san: string }).san;
       sendPlayerMove(fen, san, from, to, captured);
     },
     [
@@ -395,7 +396,8 @@ export function useGame(options?: UseGameOptions) {
             const m = msg as AIMoveMessage;
             const aiColor = playerColorRef.current === "white" ? "b" : "w";
             setAiThinking(false);
-            setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor }]);
+            const moveData = m.move || {};
+            setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: moveData.from, to: moveData.to }]);
             if (m.updatedFen) {
               try {
                 chess.load(m.updatedFen);
@@ -414,7 +416,8 @@ export function useGame(options?: UseGameOptions) {
             const aiColor = playerColorRef.current === "white" ? "b" : "w";
             setAiThinking(false);
             if (m.captured) {
-              setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor }]);
+              const moveData = m.move || {};
+              setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: moveData.from, to: moveData.to }]);
             }
             if (m.updatedFen) {
               try {
@@ -527,7 +530,8 @@ export function useGame(options?: UseGameOptions) {
             const m = msg as AIMoveMessage;
             const aiColor = playerColorRef.current === "white" ? "b" : "w";
             setAiThinking(false);
-            setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor }]);
+            const moveData = m.move || {};
+            setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: moveData.from, to: moveData.to }]);
             if (m.updatedFen) {
               try {
                 chess.load(m.updatedFen);
@@ -546,7 +550,8 @@ export function useGame(options?: UseGameOptions) {
             const aiColor = playerColorRef.current === "white" ? "b" : "w";
             setAiThinking(false);
             if (m.captured) {
-              setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor }]);
+              const moveData = m.move || {};
+              setMoveHistory((prev) => [...prev, { captured: m.captured, color: aiColor, from: moveData.from, to: moveData.to }]);
             }
             if (m.updatedFen) {
               try {
@@ -710,6 +715,8 @@ export function useGame(options?: UseGameOptions) {
 
   const VERTICAL = playerColor === "white" ? VERTICAL_WHITE : VERTICAL_BLACK;
 
+  const lastMove = moveHistory.length > 0 ? moveHistory[moveHistory.length - 1] : null;
+
   const { capturedPieces, materialDiff } = useMemo(() => {
     const byWhite: string[] = [];
     const byBlack: string[] = [];
@@ -792,6 +799,7 @@ export function useGame(options?: UseGameOptions) {
     setFenInput,
     capturedPieces,
     materialDiff,
+    lastMove,
     onLoadFen: () => {
       if (!fenInput.trim()) {
         setErrorMessage("Please enter a FEN string");

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -71,6 +71,7 @@ export default function Game() {
           onTileClick={game.onTileClick}
           HORIZONTAL={game.HORIZONTAL}
           VERTICAL={game.VERTICAL}
+          lastMove={game.lastMove}
         />
       </main>
 


### PR DESCRIPTION
## Summary
- Track from/to squares in moveHistory for both player and AI moves
- Highlight the source and destination squares of the last move with a golden background
- Works seamlessly with existing selection and valid move highlighting

## Test plan
- [ ] Play a game and verify the previous move squares are highlighted
- [ ] Verify highlighting updates correctly after each move (player and AI)
- [ ] Confirm highlighting doesn't interfere with piece selection or move validation
- [ ] Test with both white and black as player colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)