### PR TITLE
Fix board not flipping when playing as black

### DIFF
--- a/frontend/src/components/ChessBoard.tsx
+++ b/frontend/src/components/ChessBoard.tsx
@@ -34,9 +34,7 @@ export function ChessBoard({
   const flipped = orientation === "black";
   const fileLabels = flipped ? [...HORIZONTAL].reverse() : HORIZONTAL;
 
-  const rows = flipped
-    ? [...VERTICAL].reverse()
-    : VERTICAL;
+  const rows = VERTICAL;
 
   return (
     <div


### PR DESCRIPTION
## Summary
Fixed a critical rendering bug where the chess board was always displayed from white's perspective regardless of the player's color.

## Problem
When playing as black, the board failed to flip to black's perspective. The move highlighting and all UI elements remained oriented for white's viewpoint.

## Root Cause
The `ChessBoard` component was unnecessarily reversing the `VERTICAL` array when `flipped=true`. However, the `useGame` hook already provides the correct `VERTICAL` array based on the player's color, so this reversal was undoing the correct perspective.

## Solution
Removed the unnecessary `.reverse()` operation in `ChessBoard.tsx` to use the `VERTICAL` array as-is, which is already in the correct perspective for each player.

## Changes
- `frontend/src/components/ChessBoard.tsx`: Simplified board orientation logic by removing redundant array reversal

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3z84NVRAZwVNgFACKtXqT)_