### PR TITLE
Fix AI timer decreasing during player's turn

### DIFF
--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -430,8 +430,14 @@ export function useGame(options?: UseGameOptions) {
           } else if (msg.type === "time_update") {
             const m = msg as TimeUpdateMessage;
             if (m.gameId === currentGameIdRef.current) {
-              setPlayerTimeMs(m.playerTimeMs);
-              setAiTimeMs(m.aiTimeMs);
+              const currentTurn = chess.turn();
+              const pc = playerColorRef.current;
+              const pt = pc === "white" ? "w" : "b";
+              if (currentTurn === pt) {
+                setPlayerTimeMs(m.playerTimeMs);
+              } else {
+                setAiTimeMs(m.aiTimeMs);
+              }
             }
           } else if (msg.type === "error") {
             setAiThinking(false);
@@ -521,8 +527,14 @@ export function useGame(options?: UseGameOptions) {
           } else if (msg.type === "time_update") {
             const m = msg as TimeUpdateMessage;
             if (m.gameId === gid) {
-              setPlayerTimeMs(m.playerTimeMs);
-              setAiTimeMs(m.aiTimeMs);
+              const currentTurn = chess.turn();
+              const pc = playerColorRef.current;
+              const pt = pc === "white" ? "w" : "b";
+              if (currentTurn === pt) {
+                setPlayerTimeMs(m.playerTimeMs);
+              } else {
+                setAiTimeMs(m.aiTimeMs);
+              }
             }
           } else if (msg.type === "ai_move") {
             const m = msg as AIMoveMessage;


### PR DESCRIPTION
When playing WebSocket games, the AI timer was decreasing even when it was
the player's turn. This was caused by time_update messages applying both
player and AI timers without checking whose turn it actually is.

Now time_update messages only update the timer for the player whose turn it is:
- If it's the player's turn, only playerTimeMs is updated
- If it's the AI's turn, only aiTimeMs is updated

This ensures the AI timer only decreases when the AI is actually playing.

https://claude.ai/code/session_01SVSZxTBxpMaaZAWU9nvCWT