### PR TITLE
Fix AI timer decreasing during player's turn (black & white)

### DIFF
--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -379,10 +379,19 @@ export function useGame(options?: UseGameOptions) {
             const m = msg as GameStateMessage;
             if (m.gameId !== currentGameIdRef.current) return;
             playerColorRef.current = m.playerColor;
-            setPlayerTimeMs(m.playerTimeMs);
-            setAiTimeMs(m.aiTimeMs);
             setInitialTimeMs(m.timeControlMs);
             setPlayerColor(m.playerColor);
+            if (aiThinkingRef.current) {
+              setAiTimeMs(m.aiTimeMs);
+            } else {
+              const currentTurn = chess.turn();
+              const pt = m.playerColor === "white" ? "w" : "b";
+              if (currentTurn === pt) {
+                setPlayerTimeMs(m.playerTimeMs);
+              } else {
+                setAiTimeMs(m.aiTimeMs);
+              }
+            }
             if (m.fen) {
               try {
                 chess.load(m.fen);
@@ -514,10 +523,19 @@ export function useGame(options?: UseGameOptions) {
             const m = msg as GameStateMessage;
             if (m.gameId !== gid) return;
             playerColorRef.current = m.playerColor;
-            setPlayerTimeMs(m.playerTimeMs);
-            setAiTimeMs(m.aiTimeMs);
             setInitialTimeMs(m.timeControlMs);
             setPlayerColor(m.playerColor);
+            if (aiThinkingRef.current) {
+              setAiTimeMs(m.aiTimeMs);
+            } else {
+              const currentTurn = chess.turn();
+              const pt = m.playerColor === "white" ? "w" : "b";
+              if (currentTurn === pt) {
+                setPlayerTimeMs(m.playerTimeMs);
+              } else {
+                setAiTimeMs(m.aiTimeMs);
+              }
+            }
             if (m.fen) {
               try {
                 chess.load(m.fen);

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -86,8 +86,10 @@ export function useGame(options?: UseGameOptions) {
   const pendingStartRef = useRef<{ minutes: number; color: PlayerColor } | null>(null);
   const playerColorRef = useRef<PlayerColor>("white");
   const onGameCreatedRef = useRef(onGameCreated);
+  const aiThinkingRef = useRef(false);
   onGameCreatedRef.current = onGameCreated;
   playerColorRef.current = playerColor;
+  aiThinkingRef.current = aiThinking;
 
   const apiBase = useMemo(() => `${import.meta.env.VITE_backend}`, []);
 
@@ -430,13 +432,17 @@ export function useGame(options?: UseGameOptions) {
           } else if (msg.type === "time_update") {
             const m = msg as TimeUpdateMessage;
             if (m.gameId === currentGameIdRef.current) {
-              const currentTurn = chess.turn();
-              const pc = playerColorRef.current;
-              const pt = pc === "white" ? "w" : "b";
-              if (currentTurn === pt) {
-                setPlayerTimeMs(m.playerTimeMs);
-              } else {
+              if (aiThinkingRef.current) {
                 setAiTimeMs(m.aiTimeMs);
+              } else {
+                const currentTurn = chess.turn();
+                const pc = playerColorRef.current;
+                const pt = pc === "white" ? "w" : "b";
+                if (currentTurn === pt) {
+                  setPlayerTimeMs(m.playerTimeMs);
+                } else {
+                  setAiTimeMs(m.aiTimeMs);
+                }
               }
             }
           } else if (msg.type === "error") {
@@ -527,13 +533,17 @@ export function useGame(options?: UseGameOptions) {
           } else if (msg.type === "time_update") {
             const m = msg as TimeUpdateMessage;
             if (m.gameId === gid) {
-              const currentTurn = chess.turn();
-              const pc = playerColorRef.current;
-              const pt = pc === "white" ? "w" : "b";
-              if (currentTurn === pt) {
-                setPlayerTimeMs(m.playerTimeMs);
-              } else {
+              if (aiThinkingRef.current) {
                 setAiTimeMs(m.aiTimeMs);
+              } else {
+                const currentTurn = chess.turn();
+                const pc = playerColorRef.current;
+                const pt = pc === "white" ? "w" : "b";
+                if (currentTurn === pt) {
+                  setPlayerTimeMs(m.playerTimeMs);
+                } else {
+                  setAiTimeMs(m.aiTimeMs);
+                }
               }
             }
           } else if (msg.type === "ai_move") {


### PR DESCRIPTION
## Summary
Fixes a critical timer logic bug where the AI timer was decreasing when it should be paused (during the player's turn). This occurred for both white and black colors, but the root causes were different.

## Root Causes
1. **Initial fix (time_update)**: Time updates were applied to both player and AI timers without checking whose turn it was
2. **Black-specific bug**: The `game_state` message handler was overriding all timer logic by setting both timers blindly

## Solution
Implemented turn-aware timer logic across all message handlers:
- Track `aiThinkingRef` to know when AI is processing a move
- When `aiThinking = true`: only AI timer decreases  
- When `aiThinking = false`: check the board state to determine whose turn it is
- Apply consistent logic to all message types: `time_update` and `game_state`

## Changes
- Added `aiThinkingRef` to track AI thinking state in real-time
- Updated `time_update` handlers in both WebSocket connections to use turn-aware logic
- Updated `game_state` handlers to apply the same turn-aware logic
- Ensured both player colors (white and black) work correctly

## Testing
- [x] Timer behavior when playing as white
- [x] Timer behavior when playing as black
- [x] AI timer only decreases during AI's turn
- [x] Player timer only decreases during player's turn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVSZxTBxpMaaZAWU9nvCWT)_