### PR TITLE
Fix: timer display swapped when playing as black

### DIFF
--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -68,8 +68,8 @@ export default function Play() {
   const playerColor = game.playerColor;
   const botColor = playerColor === "white" ? "black" : "white";
 
-  const botTimeMs = playerColor === "white" ? game.aiTimeMs : game.playerTimeMs;
-  const myTimeMs = playerColor === "white" ? game.playerTimeMs : game.aiTimeMs;
+  const botTimeMs = game.aiTimeMs;
+  const myTimeMs = game.playerTimeMs;
   const isBotActive = !game.isPlayersTurn && !game.gameEnded;
   const isMyActive = game.isPlayersTurn && !game.gameEnded;
   const myLow = myTimeMs < 30000;


### PR DESCRIPTION
playerTimeMs is always the human player's clock and aiTimeMs is always the AI's clock in useGame — no color-based swap needed in the display layer. The previous logic inverted the two when playerColor=black, showing the bot timer counting down during the player's turn.