### PR TITLE
feat: add drag-and-drop support for moving chess pieces

### DIFF
--- a/frontend/src/components/ChessBoard.tsx
+++ b/frontend/src/components/ChessBoard.tsx
@@ -17,6 +17,11 @@ interface ChessBoardProps {
   HORIZONTAL: string[];
   VERTICAL: string[];
   lastMove?: { from?: string; to?: string } | null;
+  playerColor: PlayerColor;
+  isPlayersTurn: boolean;
+  onDragStart: (square: string) => void;
+  onDropPiece: (from: string, to: string) => void;
+  onDragEnd: () => void;
 }
 
 export function ChessBoard({
@@ -30,6 +35,11 @@ export function ChessBoard({
   HORIZONTAL,
   VERTICAL,
   lastMove,
+  playerColor,
+  isPlayersTurn,
+  onDragStart,
+  onDropPiece,
+  onDragEnd,
 }: ChessBoardProps) {
   const flipped = orientation === "black";
   const fileLabels = flipped ? [...HORIZONTAL].reverse() : HORIZONTAL;
@@ -71,11 +81,28 @@ export function ChessBoard({
             .filter(Boolean)
             .join(" ");
 
+          const pieceIsDraggable =
+            piece &&
+            isPlayersTurn &&
+            !gameEnded &&
+            ((playerColor === "white" && piece.color === "w") ||
+              (playerColor === "black" && piece.color === "b"));
+
           return (
             <div
               key={squareName}
               className={cls}
               onClick={() => !gameEnded && onTileClick(squareName)}
+              onDragOver={(e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                if (selectedSquare && !gameEnded && onDropPiece) {
+                  onDropPiece(selectedSquare, squareName);
+                }
+              }}
               role="gridcell"
               aria-label={squareName}
             >
@@ -85,6 +112,10 @@ export function ChessBoard({
                 <ChessPiece
                   piece={piece.type}
                   color={piece.color === "w" ? "white" : "black"}
+                  squareName={squareName}
+                  draggable={!!pieceIsDraggable}
+                  onDragStart={onDragStart}
+                  onDragEnd={onDragEnd}
                 />
               )}
               {isLegal && <span className="move-dot" />}

--- a/frontend/src/components/ChessBoard.tsx
+++ b/frontend/src/components/ChessBoard.tsx
@@ -99,8 +99,9 @@ export function ChessBoard({
               }}
               onDrop={(e) => {
                 e.preventDefault();
-                if (selectedSquare && !gameEnded && onDropPiece) {
-                  onDropPiece(selectedSquare, squareName);
+                const fromSquare = e.dataTransfer.getData("text/plain");
+                if (fromSquare && !gameEnded) {
+                  onDropPiece(fromSquare, squareName);
                 }
               }}
               role="gridcell"

--- a/frontend/src/components/ChessPiece.tsx
+++ b/frontend/src/components/ChessPiece.tsx
@@ -1,12 +1,25 @@
 interface ChessPieceProps {
   piece: string;
   color: "white" | "black";
+  squareName: string;
+  draggable: boolean;
+  onDragStart: (squareName: string) => void;
+  onDragEnd: () => void;
 }
 
-export function ChessPiece({ piece, color }: ChessPieceProps) {
+export function ChessPiece({ piece, color, squareName, draggable, onDragStart, onDragEnd }: ChessPieceProps) {
   const src = `/pieces/${piece.toLowerCase()}-${color}.svg`;
   return (
-    <div className="piece">
+    <div
+      className={`piece${draggable ? " draggable" : ""}`}
+      draggable={draggable}
+      onDragStart={(e) => {
+        e.dataTransfer.setData("text/plain", squareName);
+        e.dataTransfer.effectAllowed = "move";
+        onDragStart(squareName);
+      }}
+      onDragEnd={onDragEnd}
+    >
       <img src={src} alt={`${color} ${piece}`} draggable={false} />
     </div>
   );

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -332,6 +332,91 @@ export function useGame(options?: UseGameOptions) {
     ]
   );
 
+  const handleDragStart = useCallback(
+    (squareName: string) => {
+      if (aiThinking || chess.isGameOver() || gameEnded) return;
+      if (!isAdmin && !gameStarted) return;
+      if (chess.turn() !== playerTurn) return;
+
+      const moves = chess.moves({ square: squareName as Square, verbose: true }).map((m: { to: string }) => m.to);
+      if (moves.length > 0) {
+        setSelectedSquare(squareName);
+        setValidMoves(moves);
+      }
+    },
+    [chess, aiThinking, gameEnded, gameStarted, isAdmin, playerTurn]
+  );
+
+  const handleDropPiece = useCallback(
+    (fromSquare: string, toSquare: string) => {
+      if (aiThinking || chess.isGameOver() || gameEnded) {
+        setSelectedSquare(null);
+        setValidMoves([]);
+        return;
+      }
+      if (!isAdmin && !gameStarted) return;
+      if (chess.turn() !== playerTurn) return;
+
+      const verboseMoves = chess.moves({ square: fromSquare as Square, verbose: true }) as {
+        to: string;
+        piece: string;
+        from: string;
+        san: string;
+      }[];
+      const targetMove = verboseMoves.find((m) => m.to === toSquare);
+
+      if (!targetMove) {
+        setSelectedSquare(null);
+        setValidMoves([]);
+        return;
+      }
+
+      if (targetMove.piece === "p" && isPromotionSquare(toSquare)) {
+        setPendingPromotionFrom(fromSquare);
+        setPendingPromotionTo(toSquare);
+        setPromotionOpen(true);
+        return;
+      }
+
+      const move = chess.move({ from: fromSquare as Square, to: toSquare as Square });
+      setSelectedSquare(null);
+      setValidMoves([]);
+      if (!move) return;
+      const from = (move as { from: string }).from;
+      const to = (move as { to: string }).to;
+      const captured = (move as { captured?: string }).captured;
+      const san = (move as { san: string }).san;
+      setBoardState(chess.board());
+      setMoveHistory((prev) => [...prev, { captured, color: playerTurn, from, to, san }]);
+      if (!playerHasMoved) setPlayerHasMoved(true);
+      playMoveSound();
+      if (chess.isGameOver()) {
+        openEndgame(computeResult(chess), "checkmate");
+        return;
+      }
+      const fen = chess.fen();
+      sendPlayerMove(fen, san, from, to, captured);
+    },
+    [
+      chess,
+      selectedSquare,
+      aiThinking,
+      gameEnded,
+      gameStarted,
+      isAdmin,
+      playerHasMoved,
+      openEndgame,
+      sendPlayerMove,
+      playerTurn,
+      isPromotionSquare,
+    ]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setSelectedSquare(null);
+    setValidMoves([]);
+  }, []);
+
   const startNewGameViaWebSocket = useCallback(
     (minutes: number, color: PlayerColor) => {
       setPlayerColor(color);
@@ -825,6 +910,9 @@ export function useGame(options?: UseGameOptions) {
     handleRetry,
     hasRetry: !!lastFenForRetry,
     onTileClick: handleTileClick,
+    onDragStart: handleDragStart,
+    onDropPiece: handleDropPiece,
+    onDragEnd: handleDragEnd,
     playerTimeMs,
     aiTimeMs,
     initialTimeMs,

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -399,7 +399,6 @@ export function useGame(options?: UseGameOptions) {
     },
     [
       chess,
-      selectedSquare,
       aiThinking,
       gameEnded,
       gameStarted,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -552,6 +552,13 @@ body.hide-coords .square .coord { display: none; }
 }
 .piece img { width: 100%; height: 100%; object-fit: contain; display: block; }
 .square.selected .piece { transform: translateY(-2px) scale(1.04); }
+.piece.draggable {
+  pointer-events: auto;
+  cursor: grab;
+}
+.piece.draggable:active {
+  cursor: grabbing;
+}
 
 /* ---------- Right rail ---------- */
 .rail {

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -70,6 +70,11 @@ export default function Game() {
           HORIZONTAL={game.HORIZONTAL}
           VERTICAL={game.VERTICAL}
           lastMove={game.lastMove}
+          playerColor={game.playerColor}
+          isPlayersTurn={game.isPlayersTurn}
+          onDragStart={game.onDragStart}
+          onDropPiece={game.onDropPiece}
+          onDragEnd={game.onDragEnd}
         />
       </main>
 

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -121,6 +121,11 @@ export default function Play() {
             HORIZONTAL={game.HORIZONTAL}
             VERTICAL={game.VERTICAL}
             lastMove={game.lastMove}
+            playerColor={playerColor}
+            isPlayersTurn={game.isPlayersTurn}
+            onDragStart={game.onDragStart}
+            onDropPiece={game.onDropPiece}
+            onDragEnd={game.onDragEnd}
           />
 
           {/* Color picker overlay when startOpen */}

--- a/frontend/src/pages/Replay.tsx
+++ b/frontend/src/pages/Replay.tsx
@@ -169,6 +169,11 @@ export default function Replay() {
             HORIZONTAL={HORIZONTAL}
             VERTICAL={VERTICAL}
             lastMove={lastMove}
+            playerColor={orientation}
+            isPlayersTurn={false}
+            onDragStart={() => {}}
+            onDropPiece={() => {}}
+            onDragEnd={() => {}}
           />
           <div className="replay-controls">
             <button type="button" onClick={goToStart} title="Start (Home)">⏮</button>


### PR DESCRIPTION
## Summary
- Adds HTML5 native drag-and-drop for moving chess pieces on the board
- Players can drag their pieces to valid destination squares instead of only click-to-move
- Click-to-move is preserved and works alongside drag-and-drop

## Changes
- **ChessPiece** — added `squareName`, `draggable`, `onDragStart`, and `onDragEnd` props; pieces become draggable when it's the player's turn and the piece belongs to the player
- **ChessBoard** — added `onDragOver` and `onDrop` handlers on each square; determines which pieces are draggable based on player color and turn
- **useGame** — added `handleDragStart`, `handleDropPiece`, and `handleDragEnd` callbacks that mirror the existing click-to-move logic (selection, move validation, promotion, game-end detection)
- **Play / Game / Replay** — wired new props; Replay has drag disabled (read-only)
- **CSS** — added `.piece.draggable` styles with grab/grabbing cursors and `pointer-events: auto` override