### PR TITLE
Fix threefold repetition from the starting position

### DIFF
--- a/backend/game_rules.py
+++ b/backend/game_rules.py
@@ -1,8 +1,21 @@
 """Chess game rules checking (draw conditions, etc)."""
+from typing import Optional
+
 import chess
 
 
-def check_3_move_repetition(moves: list[dict]) -> bool:
+def _position_state_from_fen(fen: str) -> Optional[str]:
+    """Return the FEN fields that define a repeatable chess position."""
+    parts = fen.split()
+    if len(parts) >= 4:
+        return " ".join(parts[:4])
+    return None
+
+
+def check_3_move_repetition(
+    moves: list[dict],
+    initial_fen: Optional[str] = chess.STARTING_FEN,
+) -> bool:
     """Check if the current position has occurred 3 times in the game.
 
     Looks at the board state (position without move counters) from the FEN.
@@ -13,13 +26,17 @@ def check_3_move_repetition(moves: list[dict]) -> bool:
 
     # Extract the board state portion of each FEN (everything except halfmove and fullmove clocks)
     position_states = []
+    if initial_fen:
+        initial_position_state = _position_state_from_fen(initial_fen)
+        if initial_position_state:
+            position_states.append(initial_position_state)
+
     for move in moves:
         fen = move["fen"]
         # Extract just the position part: "rnbq... w KQkq - 0 1" -> "rnbq... w KQkq -"
-        parts = fen.split()
-        if len(parts) >= 4:
+        position_state = _position_state_from_fen(fen)
+        if position_state:
             # Position state is: board + active color + castling + en passant
-            position_state = " ".join(parts[:4])
             position_states.append(position_state)
 
     # Check if the latest position (current board state) has appeared 3 times

--- a/backend/test_game_rules.py
+++ b/backend/test_game_rules.py
@@ -1,4 +1,5 @@
 """Tests for game rules checking."""
+import chess
 import pytest
 from game_rules import check_3_move_repetition
 
@@ -34,6 +35,18 @@ def test_triple_repetition():
         {"fen": other_fen},
         {"fen": initial_fen},  # 3rd time
     ]
+    assert check_3_move_repetition(moves) is True
+
+
+def test_repetition_counts_starting_position():
+    """Test that the initial board position counts as a repetition occurrence."""
+    board = chess.Board()
+    moves = []
+    for uci in ["g1f3", "g8f6", "f3g1", "f6g8", "g1f3", "g8f6", "f3g1", "f6g8"]:
+        board.push(chess.Move.from_uci(uci))
+        moves.append({"fen": board.fen()})
+
+    assert board.can_claim_threefold_repetition() is True
     assert check_3_move_repetition(moves) is True
 
 


### PR DESCRIPTION
## Problem found
Threefold repetition detection only counted positions stored after moves. Because the initial board position is not stored as a move, a game that returns to the starting position twice after play is incorrectly left active even though the starting position has occurred three times.

## Evidence / reproduction steps
From the starting position, play:

```text
1. Nf3 Nf6 2. Ng1 Ng8 3. Nf3 Nf6 4. Ng1 Ng8
```

`python-chess` reports `can_claim_threefold_repetition() == True`, but the existing `check_3_move_repetition()` returned `False` because it saw only the two post-move occurrences.

## What changed
- Added a small FEN position-state helper for the four repeat-relevant FEN fields.
- Count the standard initial FEN as an occurrence before checking stored move FENs.

## Tests added or updated
- Added a regression test for the knight-shuffle repetition that returns to the starting position twice.

## Commands run
```bash
PYTHONPATH=backend /tmp/gambitron-codex-venv/bin/python -m pytest backend/test_game_rules.py -q
PYTHONPATH=backend /tmp/gambitron-codex-venv/bin/python -m pytest backend -q
```

## Screenshots / before-after notes
Not applicable; backend rules fix only.

## Risks / follow-up work
This assumes backend WebSocket games start from the standard chess initial position, which is how `handle_start_game` initializes games today. If custom starting FEN games are later added, callers should pass that initial FEN into `check_3_move_repetition()`.