### PR TITLE
Fix en passant captures in replay metadata

### DIFF
--- a/backend/db/moves.py
+++ b/backend/db/moves.py
@@ -2,6 +2,7 @@
 import io
 import os
 import uuid
+from typing import Optional
 
 import chess
 import chess.pgn
@@ -21,6 +22,14 @@ PIECE_TO_SYMBOL = {
 }
 
 
+def _captured_piece_for_move(board: chess.Board, move: chess.Move):
+    """Return the captured piece for normal and en-passant captures."""
+    if board.is_en_passant(move):
+        captured_square = chess.square(chess.square_file(move.to_square), chess.square_rank(move.from_square))
+        return board.piece_at(captured_square)
+    return board.piece_at(move.to_square)
+
+
 def _ensure_pgn_dir() -> None:
     """Create PGN storage directory if it doesn't exist."""
     path = PGN_STORAGE_DIR
@@ -28,7 +37,7 @@ def _ensure_pgn_dir() -> None:
         os.makedirs(path, exist_ok=True)
 
 
-def _build_uci(san: str, from_square: str | None, to_square: str | None) -> str:
+def _build_uci(san: str, from_square: Optional[str], to_square: Optional[str]) -> str:
     """Build UCI string from SAN and squares. Handles promotion (e7e8=Q -> e7e8q)."""
     if from_square and to_square:
         if "=" in san:
@@ -43,9 +52,9 @@ async def append_move(
     ply: int,
     fen: str,
     san: str,
-    from_square: str | None = None,
-    to_square: str | None = None,
-    captured: str | None = None,
+    from_square: Optional[str] = None,
+    to_square: Optional[str] = None,
+    captured: Optional[str] = None,
 ) -> bool:
     """Append a move to in-memory storage. Returns True."""
     if game_id not in _memory_moves:
@@ -84,7 +93,7 @@ def _pgn_to_moves_list(pgn: str) -> list[dict]:
             to_sq = chess.square_name(move.to_square)
             captured = None
             if board.is_capture(move):
-                piece = board.piece_at(move.to_square)
+                piece = _captured_piece_for_move(board, move)
                 if piece:
                     captured = PIECE_TO_SYMBOL.get(piece.piece_type)
             board.push(move)

--- a/backend/db/test_moves.py
+++ b/backend/db/test_moves.py
@@ -1,0 +1,18 @@
+"""Tests for persisted move reconstruction."""
+import importlib
+import sys
+import types
+
+
+def test_pgn_to_moves_records_en_passant_capture():
+    """Test that replay metadata includes the pawn captured en passant."""
+    sys.modules["db.games"] = types.SimpleNamespace()
+    moves_module = importlib.import_module("db.moves")
+
+    _pgn_to_moves_list = moves_module._pgn_to_moves_list
+    moves = _pgn_to_moves_list("1. e4 h5 2. e5 d5 3. exd6")
+
+    assert moves[-1]["san"] == "exd6"
+    assert moves[-1]["from_square"] == "e5"
+    assert moves[-1]["to_square"] == "d6"
+    assert moves[-1]["captured"] == "p"


### PR DESCRIPTION
## Problem found
PGN replay reconstruction treated captures as pieces located on the destination square before the move is pushed. That misses en-passant captures, where the captured pawn is adjacent to the destination square.

## Evidence / reproduction steps
Replay parsing this PGN should record a black pawn captured by White's final move:

```text
1. e4 h5 2. e5 d5 3. exd6
```

Before this change, `_pgn_to_moves_list()` returned `captured: None` for `exd6` because `d6` is empty before an en-passant move is pushed.

## What changed
- Added en-passant-aware capture lookup in `backend/db/moves.py`.
- Used that lookup when reconstructing captured pieces from stored PGN.
- Converted touched optional annotations in `backend/db/moves.py` to `Optional[...]` so the new parser test runs on the local Python 3.9 test environment.

## Tests added or updated
- Added `backend/db/test_moves.py` coverage for replay metadata after an en-passant capture.

## Commands run
```bash
PYTHONPATH=backend /tmp/gambitron-codex-venv/bin/python -m pytest backend/db/test_moves.py backend/test_chess_engine.py -q
PYTHONPATH=backend /tmp/gambitron-codex-venv/bin/python -m pytest backend -q
git diff --check
```

## Screenshots / before-after notes
No screenshots; backend replay metadata fix. Visible effect: game history/replay can now include pawns captured en passant instead of omitting them.

## Risks / follow-up work
Low risk; the helper uses `python-chess` `Board.is_en_passant(move)` and falls back to the previous destination-square lookup for normal captures.