### PR TITLE
Validate player moves against the server board

### DIFF
--- a/backend/websocket/handlers.py
+++ b/backend/websocket/handlers.py
@@ -1,5 +1,8 @@
 """WebSocket message handlers."""
+from __future__ import annotations
+
 import asyncio
+from dataclasses import dataclass
 import json
 import uuid
 
@@ -12,6 +15,25 @@ from db import moves as moves_db
 from game_rules import check_3_move_repetition
 from websocket import connection_manager
 from websocket import timers as timers_module
+
+PIECE_TO_SYMBOL = {
+    chess.PAWN: "p",
+    chess.KNIGHT: "n",
+    chess.BISHOP: "b",
+    chess.ROOK: "r",
+    chess.QUEEN: "q",
+}
+
+PROMOTION_PIECES = {"q", "r", "b", "n"}
+
+
+@dataclass
+class ValidatedPlayerMove:
+    board: chess.Board
+    san: str
+    from_square: str
+    to_square: str
+    captured: str | None
 
 
 async def _run_ai(fen: str):
@@ -26,6 +48,90 @@ def _termination_from_result(result: str) -> str:
     if result == "1/2-1/2":
         return "draw"
     return "unknown"
+
+
+def _captured_piece_symbol(board: chess.Board, move: chess.Move) -> str | None:
+    """Return captured piece metadata before pushing a legal move."""
+    if board.is_en_passant(move):
+        captured_square = chess.square(chess.square_file(move.to_square), chess.square_rank(move.from_square))
+        captured_piece = board.piece_at(captured_square)
+    else:
+        captured_piece = board.piece_at(move.to_square)
+    if not captured_piece:
+        return None
+    return PIECE_TO_SYMBOL.get(captured_piece.piece_type)
+
+
+def _promotion_from_payload(data: dict, san: str | None) -> str:
+    promotion = data.get("promotion")
+    if isinstance(promotion, str) and promotion.lower() in PROMOTION_PIECES:
+        return promotion.lower()
+    if san and "=" in san:
+        candidate = san.split("=")[-1].strip().lower()[:1]
+        if candidate in PROMOTION_PIECES:
+            return candidate
+    return ""
+
+
+def _move_from_payload(
+    board: chess.Board,
+    data: dict,
+    san: str | None,
+    from_sq: str | None,
+    to_sq: str | None,
+) -> chess.Move | None:
+    """Build a move from client payload fields against the server board."""
+    if from_sq and to_sq:
+        try:
+            return chess.Move.from_uci(f"{from_sq}{to_sq}{_promotion_from_payload(data, san)}")
+        except ValueError:
+            return None
+    if san:
+        try:
+            return board.parse_san(san)
+        except ValueError:
+            return None
+    return None
+
+
+def _validate_player_move(
+    previous_fen: str,
+    submitted_fen: str,
+    data: dict,
+    san: str | None,
+    from_sq: str | None,
+    to_sq: str | None,
+) -> ValidatedPlayerMove | None:
+    """Validate a client move from the server's previous FEN to the submitted FEN."""
+    try:
+        previous_board = chess.Board(previous_fen)
+    except ValueError:
+        return None
+
+    move = _move_from_payload(previous_board, data, san, from_sq, to_sq)
+    if move is None or move not in previous_board.legal_moves:
+        return None
+
+    canonical_san = previous_board.san(move)
+    canonical_from = chess.square_name(move.from_square)
+    canonical_to = chess.square_name(move.to_square)
+    captured = _captured_piece_symbol(previous_board, move)
+
+    previous_board.push(move)
+    try:
+        submitted_board = chess.Board(submitted_fen)
+    except ValueError:
+        return None
+    if submitted_board.fen() != previous_board.fen():
+        return None
+
+    return ValidatedPlayerMove(
+        board=previous_board,
+        san=canonical_san,
+        from_square=canonical_from,
+        to_square=canonical_to,
+        captured=captured,
+    )
 
 
 async def handle_start_game(ws: WebSocket, data: dict) -> dict | None:
@@ -75,11 +181,15 @@ async def handle_player_move(ws: WebSocket, data: dict) -> dict | None:
         return {"type": "error", "message": "Game not found or already ended"}
 
     player_color = game.get("player_color", "white")
+    timer = timers_module.get_timer(game_id)
+    if not timer:
+        return {"type": "error", "message": "Game state unavailable"}
+    previous_fen = timer["fen"]
+
     times = timers_module.apply_elapsed(game_id)
     if times:
         pt, at = times
-        t = timers_module.get_timer(game_id)
-        if t and timers_module.is_player_turn(fen, player_color) and pt <= 0:
+        if timers_module.is_player_turn(previous_fen, player_color) and pt <= 0:
             timers_module.mark_ended(game_id)
             timers_module.remove_game(game_id)
             timeout_result = "0-1" if player_color == "white" else "1-0"
@@ -91,24 +201,33 @@ async def handle_player_move(ws: WebSocket, data: dict) -> dict | None:
                 "termination": "timeout",
             }
 
+    if not timers_module.is_player_turn(previous_fen, player_color):
+        return {"type": "error", "message": "Not player's turn"}
+
+    validated_move = _validate_player_move(
+        previous_fen,
+        fen,
+        data,
+        san,
+        from_sq,
+        to_sq,
+    )
+    if validated_move is None:
+        return {"type": "error", "message": "Illegal move"}
+    board = validated_move.board
+    fen = board.fen()
+    san = validated_move.san
+    from_sq = validated_move.from_square
+    to_sq = validated_move.to_square
+    player_captured = validated_move.captured
+
     move_count = await moves_db.get_move_count(game_id)
     player_ply = move_count + 1
 
     if player_color == "white" and move_count == 0:
         timers_module.clear_player_first_move_pending(game_id)
 
-    if san is None and from_sq and to_sq:
-        san = f"{from_sq}{to_sq}"
-    if not san:
-        san = ""
-
-    player_captured = data.get("captured")
     await moves_db.append_move(game_id, player_ply, fen, san, from_sq, to_sq, player_captured)
-
-    try:
-        board = chess.Board(fen)
-    except ValueError:
-        return {"type": "error", "message": "Invalid FEN"}
 
     # Check for draw by 3-move repetition after player move
     all_moves = await moves_db.get_moves_by_game(game_id)

--- a/backend/websocket/test_handlers.py
+++ b/backend/websocket/test_handlers.py
@@ -1,0 +1,195 @@
+"""Tests for WebSocket game message handlers."""
+import asyncio
+import importlib
+import sys
+import types
+import uuid
+
+import chess
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def cleanup_handler_modules():
+    yield
+    for module_name in ("websocket.handlers", "websocket.timers"):
+        sys.modules.pop(module_name, None)
+
+
+def _load_handlers(monkeypatch):
+    """Load handlers with DB modules stubbed for pure handler tests."""
+    for module_name in ("websocket.handlers", "websocket.timers"):
+        sys.modules.pop(module_name, None)
+
+    games: dict[uuid.UUID, dict] = {}
+    appended_moves: list[dict] = []
+    timers_state: dict[uuid.UUID, dict] = {}
+
+    async def get_game(game_id):
+        return games.get(game_id)
+
+    async def get_move_count(game_id):
+        return len([move for move in appended_moves if move["game_id"] == game_id])
+
+    async def append_move(game_id, ply, fen, san, from_square=None, to_square=None, captured=None):
+        appended_moves.append(
+            {
+                "game_id": game_id,
+                "ply": ply,
+                "fen": fen,
+                "san": san,
+                "from_square": from_square,
+                "to_square": to_square,
+                "captured": captured,
+            }
+        )
+        return True
+
+    async def get_moves_by_game(game_id):
+        return [
+            {key: value for key, value in move.items() if key != "game_id"}
+            for move in appended_moves
+            if move["game_id"] == game_id
+        ]
+
+    async def finalize_game_to_pgn(*args, **kwargs):
+        return True
+
+    monkeypatch.setitem(sys.modules, "db.games", types.SimpleNamespace(get_game=get_game))
+    monkeypatch.setitem(
+        sys.modules,
+        "db.moves",
+        types.SimpleNamespace(
+            get_move_count=get_move_count,
+            append_move=append_move,
+            get_moves_by_game=get_moves_by_game,
+            finalize_game_to_pgn=finalize_game_to_pgn,
+        ),
+    )
+
+    def is_player_turn(fen, player_color):
+        board = chess.Board(fen)
+        return (player_color == "white") == (board.turn == chess.WHITE)
+
+    def register_game(game_id, time_control_ms, player_color, fen):
+        timers_state[game_id] = {
+            "player_time_ms": time_control_ms,
+            "ai_time_ms": time_control_ms,
+            "player_color": player_color,
+            "fen": fen,
+            "game_ended": False,
+            "player_first_move_pending": player_color == "white",
+        }
+
+    def get_timer(game_id):
+        return timers_state.get(game_id)
+
+    def apply_elapsed(game_id):
+        timer = timers_state.get(game_id)
+        if not timer:
+            return None
+        return timer["player_time_ms"], timer["ai_time_ms"]
+
+    def update_fen(game_id, fen):
+        timers_state[game_id]["fen"] = fen
+
+    def clear_player_first_move_pending(game_id):
+        timers_state[game_id]["player_first_move_pending"] = False
+
+    def mark_ended(game_id):
+        timers_state[game_id]["game_ended"] = True
+
+    def remove_game(game_id):
+        timers_state.pop(game_id, None)
+
+    fake_timers = types.SimpleNamespace(
+        _game_timers=timers_state,
+        is_player_turn=is_player_turn,
+        register_game=register_game,
+        get_timer=get_timer,
+        apply_elapsed=apply_elapsed,
+        update_fen=update_fen,
+        clear_player_first_move_pending=clear_player_first_move_pending,
+        mark_ended=mark_ended,
+        remove_game=remove_game,
+    )
+    monkeypatch.setitem(sys.modules, "websocket.timers", fake_timers)
+
+    handlers = importlib.import_module("websocket.handlers")
+    return handlers, fake_timers, games, appended_moves
+
+
+def test_handle_player_move_rejects_illegal_client_transition(monkeypatch):
+    """A client cannot advance from the server FEN with an illegal move."""
+    handlers, timers, games, appended_moves = _load_handlers(monkeypatch)
+    game_id = uuid.uuid4()
+    games[game_id] = {"player_color": "white", "ended_at": None}
+    timers.register_game(game_id, 60_000, "white", chess.STARTING_FEN)
+
+    async def fail_ai(_fen):
+        raise AssertionError("AI should not run for an illegal player move")
+
+    monkeypatch.setattr(handlers, "_run_ai", fail_ai)
+
+    result = asyncio.run(
+        handlers.handle_player_move(
+            object(),
+            {
+                "gameId": str(game_id),
+                "fen": "rnbqkbnr/pppppppp/8/4P3/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+                "from": "e2",
+                "to": "e5",
+            },
+        )
+    )
+
+    assert result == {"type": "error", "message": "Illegal move"}
+    assert appended_moves == []
+    assert timers.get_timer(game_id)["fen"] == chess.STARTING_FEN
+
+
+def test_handle_player_move_records_valid_move_from_server_board(monkeypatch):
+    """Valid moves are canonicalized from the server board before storage."""
+    handlers, timers, games, appended_moves = _load_handlers(monkeypatch)
+    game_id = uuid.uuid4()
+    games[game_id] = {"player_color": "white", "ended_at": None}
+    timers.register_game(game_id, 60_000, "white", chess.STARTING_FEN)
+
+    player_board = chess.Board()
+    player_board.push(chess.Move.from_uci("e2e4"))
+
+    async def fake_ai(fen):
+        ai_board = chess.Board(fen)
+        ai_move = chess.Move.from_uci("e7e5")
+        ai_san = ai_board.san(ai_move)
+        ai_board.push(ai_move)
+        return {
+            "updated_fen": ai_board.fen(),
+            "result": ai_board.result(),
+            "san": ai_san,
+            "from_square": "e7",
+            "to_square": "e5",
+            "captured": None,
+        }
+
+    monkeypatch.setattr(handlers, "_run_ai", fake_ai)
+
+    result = asyncio.run(
+        handlers.handle_player_move(
+            object(),
+            {
+                "gameId": str(game_id),
+                "fen": player_board.fen(),
+                "san": "not trusted",
+                "from": "e2",
+                "to": "e4",
+                "captured": "q",
+            },
+        )
+    )
+
+    assert result["type"] == "ai_move"
+    assert appended_moves[0]["san"] == "e4"
+    assert appended_moves[0]["from_square"] == "e2"
+    assert appended_moves[0]["to_square"] == "e4"
+    assert appended_moves[0]["captured"] is None


### PR DESCRIPTION
## Problem found
`handle_player_move` trusted the client-provided post-move FEN and capture/SAN metadata. A client could submit an illegal transition, such as moving the pawn from `e2` to `e5`, and the server would append that position before continuing the game from it.

## Evidence / reproduction steps
Starting from the normal initial FEN, send a `player_move` payload with:

```json
{
  "fen": "rnbqkbnr/pppppppp/8/4P3/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
  "from": "e2",
  "to": "e5"
}
```

That FEN is internally valid, but the transition from the server's previous board is illegal. The new regression test proves the handler now rejects it before appending any move or running the AI.

## What changed
- Validate player moves from the server timer's previous FEN instead of trusting the submitted FEN alone.
- Require the submitted FEN to match the board after the legal move is pushed.
- Derive SAN, from/to squares, and captured-piece metadata server-side after validation.
- Reject moves when the server has no active game state or when it is not the player's turn.

## Tests added or updated
- Added WebSocket handler tests for rejecting an illegal client transition.
- Added a valid-move test proving the server canonicalizes SAN/capture metadata instead of trusting client values.

## Commands run
```bash
PYTHONPATH=backend /tmp/gambitron-codex-venv/bin/python -m pytest backend/websocket/test_handlers.py -q
PYTHONPATH=backend /tmp/gambitron-codex-venv/bin/python -m pytest backend -q
git diff --check
```

## Screenshots / before-after notes
Not applicable; backend move-validation fix only.

## Risks / follow-up work
The handler now requires an active timer/server game state for player moves. That matches the existing reconnect behavior (`Game state unavailable` without timer state), but games cannot accept moves after a backend restart unless timer restoration is added later.