### PR TITLE
[codex] Add architecture diagrams to About and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@
 
 ## How It Works
 
-```
-React (Vercel) ←——WebSocket——→ FastAPI (EC2) ←——→ PostgreSQL
-```
+![Gambitron Architecture](frontend/public/gambitron-architecture.svg)
 
-The frontend communicates over a persistent WebSocket. The server runs the AI on a thread pool, owns the clocks (100 ms tick), and persists games as PGN. A REST API (`GET /games`, `GET /games/:id/moves`) powers the history and replay pages.
+The browser handles the board UI, legal-move hints, and replay controls. Live games run through a persistent WebSocket to FastAPI, which owns game sessions, server-side clocks, AI turns, and endgame detection.
+
+FastAPI runs the minimax engine off the event loop, broadcasts `ai_move` and `time_update` messages, and finalizes completed games to PGN. PostgreSQL stores finished games so `GET /games` and `GET /games/:id/moves` can power the History and Replay pages.
 
 **AI evaluation factors:** material values, piece-square tables, center control, pawn advancement, bishop pair bonus, rook mobility, king safety.
+
+Editable diagram source: [frontend/public/gambitron-architecture.drawio](frontend/public/gambitron-architecture.drawio)
 
 ## Quick Start
 

--- a/frontend/public/gambitron-architecture.drawio
+++ b/frontend/public/gambitron-architecture.drawio
@@ -1,0 +1,65 @@
+<mxfile host="app.diagrams.net" modified="2026-05-16T00:00:00.000Z" agent="Codex" version="24.7.17" type="device">
+  <diagram id="gambitron-architecture" name="Gambitron Architecture">
+    <mxGraphModel dx="1120" dy="660" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1120" pageHeight="660" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="title" value="Gambitron architecture&lt;br&gt;&lt;font style=&quot;font-size: 18px;&quot;&gt;One real-time game loop, one durable record.&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=none;fillColor=none;fontColor=#f1ece4;align=left;verticalAlign=top;fontStyle=1;fontSize=24;" vertex="1" parent="1">
+          <mxGeometry x="56" y="40" width="760" height="80" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="client-group" value="Client&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;React · TypeScript · Vercel&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#29251f;strokeColor=#544c42;fontColor=#f1ece4;align=left;verticalAlign=top;spacing=24;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="56" y="162" width="300" height="300" as="geometry"/>
+        </mxCell>
+        <mxCell id="client-ui" value="Board, clocks, dialogs&lt;br&gt;&lt;font style=&quot;font-size: 11px;&quot;&gt;routes: play · history · replay&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="80" y="256" width="252" height="54" as="geometry"/>
+        </mxCell>
+        <mxCell id="client-chess" value="chess.js move handling&lt;br&gt;&lt;font style=&quot;font-size: 11px;&quot;&gt;legal squares · FEN · SAN&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="80" y="328" width="252" height="54" as="geometry"/>
+        </mxCell>
+        <mxCell id="client-ws" value="WebSocket + REST clients" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="80" y="400" width="252" height="38" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="backend-group" value="Backend&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;FastAPI · EC2&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#29251f;strokeColor=#544c42;fontColor=#f1ece4;align=left;verticalAlign=top;spacing=24;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="410" y="162" width="300" height="300" as="geometry"/>
+        </mxCell>
+        <mxCell id="backend-ws" value="/ws game session&lt;br&gt;&lt;font style=&quot;font-size: 11px;&quot;&gt;start · move · subscribe&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="434" y="256" width="252" height="54" as="geometry"/>
+        </mxCell>
+        <mxCell id="backend-timer" value="Timer loop&lt;br&gt;&lt;font style=&quot;font-size: 11px;&quot;&gt;100 ms tick · timeouts&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="434" y="328" width="252" height="54" as="geometry"/>
+        </mxCell>
+        <mxCell id="backend-engine" value="Minimax engine thread" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="434" y="400" width="252" height="38" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="data-group" value="Data &amp; replay&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;PostgreSQL · PGN&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#29251f;strokeColor=#544c42;fontColor=#f1ece4;align=left;verticalAlign=top;spacing=24;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="764" y="162" width="300" height="300" as="geometry"/>
+        </mxCell>
+        <mxCell id="data-games" value="games table&lt;br&gt;&lt;font style=&quot;font-size: 11px;&quot;&gt;id · result · time control&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="788" y="256" width="252" height="54" as="geometry"/>
+        </mxCell>
+        <mxCell id="data-pgn" value="PGN finalization&lt;br&gt;&lt;font style=&quot;font-size: 11px;&quot;&gt;written when a game ends&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="788" y="328" width="252" height="54" as="geometry"/>
+        </mxCell>
+        <mxCell id="data-rest" value="REST history endpoints" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#211f1b;strokeColor=#62594d;fontColor=#f1ece4;align=left;spacing=14;" vertex="1" parent="1">
+          <mxGeometry x="788" y="400" width="252" height="38" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge-ws" value="WebSocket /ws" style="endArrow=block;html=1;rounded=0;strokeColor=#d69b55;fontColor=#9b9184;edgeStyle=orthogonalEdgeStyle;" edge="1" parent="1" source="client-ws" target="backend-ws">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="edge-persist" value="persist" style="endArrow=block;html=1;rounded=0;strokeColor=#d69b55;fontColor=#9b9184;edgeStyle=orthogonalEdgeStyle;" edge="1" parent="1" source="backend-engine" target="data-pgn">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="edge-rest" value="GET /games · GET /games/:id/moves" style="endArrow=block;html=1;rounded=0;strokeColor=#7d6f60;dashed=1;fontColor=#9b9184;edgeStyle=orthogonalEdgeStyle;" edge="1" parent="1" source="data-rest" target="client-ui">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="edge-updates" value="ai_move · time_update" style="endArrow=block;html=1;rounded=0;strokeColor=#7d6f60;dashed=1;fontColor=#9b9184;edgeStyle=orthogonalEdgeStyle;" edge="1" parent="1" source="backend-timer" target="client-ui">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/frontend/public/gambitron-architecture.svg
+++ b/frontend/public/gambitron-architecture.svg
@@ -1,0 +1,132 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="660" viewBox="0 0 1120 660" role="img" aria-labelledby="title desc">
+  <title id="title">Gambitron application architecture</title>
+  <desc id="desc">React client communicates with a FastAPI backend over WebSocket and REST. The backend runs timers, the chess engine, and stores finished games in PostgreSQL as PGN for replay.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M2 2 L10 6 L2 10 Z" fill="#d69b55"/>
+    </marker>
+    <style>
+      .bg { fill: #201d19; }
+      .panel { fill: #29251f; stroke: #544c42; stroke-width: 1.4; }
+      .node { fill: #211f1b; stroke: #62594d; stroke-width: 1.2; }
+      .node-soft { fill: #24211d; stroke: #4d463e; stroke-width: 1.1; }
+      .ink { fill: #f1ece4; font: 600 19px Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .dim { fill: #b9afa2; font: 14px Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .tiny { fill: #9b9184; font: 12px "JetBrains Mono", "SF Mono", Menlo, monospace; }
+      .mono { fill: #d69b55; font: 12px "JetBrains Mono", "SF Mono", Menlo, monospace; }
+      .heading { fill: #f1ece4; font: 400 31px Georgia, "Times New Roman", serif; }
+      .eyebrow { fill: #d69b55; font: 12px "JetBrains Mono", "SF Mono", Menlo, monospace; text-transform: uppercase; }
+      .line { stroke: #d69b55; stroke-width: 2.2; fill: none; marker-end: url(#arrow); }
+      .line-soft { stroke: #7d6f60; stroke-width: 1.5; fill: none; stroke-dasharray: 5 6; marker-end: url(#arrow); }
+      .step { fill: #28241f; stroke: #51493f; stroke-width: 1; }
+      .step-num { fill: #d69b55; font: 600 13px "JetBrains Mono", "SF Mono", Menlo, monospace; }
+      .step-text { fill: #eee8df; font: 13px Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="1120" height="660"/>
+
+  <text class="eyebrow" x="56" y="58">Gambitron architecture</text>
+  <text class="heading" x="56" y="95">One real-time game loop, one durable record.</text>
+  <text class="dim" x="56" y="123">The browser keeps the board responsive while FastAPI owns live play, clocks, engine replies, and replay data.</text>
+
+  <g transform="translate(56 162)">
+    <rect class="panel" width="300" height="300" rx="8"/>
+    <text class="ink" x="24" y="42">Client</text>
+    <text class="mono" x="24" y="65">React · TypeScript · Vercel</text>
+
+    <rect class="node" x="24" y="94" width="252" height="54" rx="6"/>
+    <text class="dim" x="44" y="118">Board, clocks, dialogs</text>
+    <text class="tiny" x="44" y="136">routes: play · history · replay</text>
+
+    <rect class="node" x="24" y="166" width="252" height="54" rx="6"/>
+    <text class="dim" x="44" y="190">chess.js move handling</text>
+    <text class="tiny" x="44" y="208">legal squares · FEN · SAN</text>
+
+    <rect class="node" x="24" y="238" width="252" height="38" rx="6"/>
+    <text class="dim" x="44" y="262">WebSocket + REST clients</text>
+  </g>
+
+  <g transform="translate(410 162)">
+    <rect class="panel" width="300" height="300" rx="8"/>
+    <text class="ink" x="24" y="42">Backend</text>
+    <text class="mono" x="24" y="65">FastAPI · EC2</text>
+
+    <rect class="node" x="24" y="94" width="252" height="54" rx="6"/>
+    <text class="dim" x="44" y="118">/ws game session</text>
+    <text class="tiny" x="44" y="136">start · move · subscribe</text>
+
+    <rect class="node" x="24" y="166" width="252" height="54" rx="6"/>
+    <text class="dim" x="44" y="190">Timer loop</text>
+    <text class="tiny" x="44" y="208">100 ms tick · timeouts</text>
+
+    <rect class="node" x="24" y="238" width="252" height="38" rx="6"/>
+    <text class="dim" x="44" y="262">Minimax engine thread</text>
+  </g>
+
+  <g transform="translate(764 162)">
+    <rect class="panel" width="300" height="300" rx="8"/>
+    <text class="ink" x="24" y="42">Data &amp; replay</text>
+    <text class="mono" x="24" y="65">PostgreSQL · PGN</text>
+
+    <rect class="node" x="24" y="94" width="252" height="54" rx="6"/>
+    <text class="dim" x="44" y="118">games table</text>
+    <text class="tiny" x="44" y="136">id · result · time control</text>
+
+    <rect class="node" x="24" y="166" width="252" height="54" rx="6"/>
+    <text class="dim" x="44" y="190">PGN finalization</text>
+    <text class="tiny" x="44" y="208">written when a game ends</text>
+
+    <rect class="node" x="24" y="238" width="252" height="38" rx="6"/>
+    <text class="dim" x="44" y="262">REST history endpoints</text>
+  </g>
+
+  <path class="line" d="M356 282 H410"/>
+  <text class="tiny" x="365" y="266">WebSocket /ws</text>
+
+  <path class="line" d="M710 282 H764"/>
+  <text class="tiny" x="718" y="266">persist</text>
+
+  <path class="line-soft" d="M764 400 C690 430 430 430 356 400"/>
+  <text class="tiny" x="502" y="438">GET /games · GET /games/:id/moves</text>
+
+  <path class="line-soft" d="M410 331 H356"/>
+  <text class="tiny" x="360" y="354">ai_move · time_update</text>
+
+  <g transform="translate(56 520)">
+    <text class="eyebrow" x="0" y="-18">Move lifecycle</text>
+
+    <rect class="step" x="0" y="0" width="180" height="70" rx="7"/>
+    <text class="step-num" x="18" y="27">01</text>
+    <text class="step-text" x="54" y="27">Start game</text>
+    <text class="tiny" x="18" y="50">time + side</text>
+
+    <path class="line" d="M185 35 H215"/>
+
+    <rect class="step" x="220" y="0" width="180" height="70" rx="7"/>
+    <text class="step-num" x="238" y="27">02</text>
+    <text class="step-text" x="274" y="27">Player move</text>
+    <text class="tiny" x="238" y="50">FEN + SAN over WS</text>
+
+    <path class="line" d="M405 35 H435"/>
+
+    <rect class="step" x="440" y="0" width="180" height="70" rx="7"/>
+    <text class="step-num" x="458" y="27">03</text>
+    <text class="step-text" x="494" y="27">Engine search</text>
+    <text class="tiny" x="458" y="50">minimax + pruning</text>
+
+    <path class="line" d="M625 35 H655"/>
+
+    <rect class="step" x="660" y="0" width="180" height="70" rx="7"/>
+    <text class="step-num" x="678" y="27">04</text>
+    <text class="step-text" x="714" y="27">AI reply</text>
+    <text class="tiny" x="678" y="50">board + clocks update</text>
+
+    <path class="line" d="M845 35 H875"/>
+
+    <rect class="step" x="880" y="0" width="180" height="70" rx="7"/>
+    <text class="step-num" x="898" y="27">05</text>
+    <text class="step-text" x="934" y="27">Replay later</text>
+    <text class="tiny" x="898" y="50">PGN from Postgres</text>
+  </g>
+</svg>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -826,6 +826,75 @@ body.hide-coords .square .coord { display: none; }
   line-height: 1.7;
 }
 
+.architecture-copy {
+  max-width: 720px;
+  margin-bottom: 24px;
+}
+.architecture-copy h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 38px;
+  line-height: 1.05;
+  margin: 0 0 12px;
+}
+.architecture-copy p {
+  color: var(--ink-dim);
+  font-size: 15px;
+  line-height: 1.7;
+  margin: 0;
+}
+.architecture-figure {
+  margin: 0 0 28px;
+  border: 1px solid var(--line-soft);
+  background: var(--bg-elev);
+  overflow-x: auto;
+}
+.architecture-figure img {
+  display: block;
+  width: 100%;
+  min-width: 760px;
+  height: auto;
+}
+.architecture-figure figcaption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--line-soft);
+  padding: 12px 16px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+}
+.architecture-figure a {
+  color: var(--accent);
+}
+
+.flow-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--line-soft);
+  border: 1px solid var(--line-soft);
+}
+.flow-step {
+  background: var(--bg);
+  padding: 22px 20px 24px;
+}
+.flow-step h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  margin: 0 0 8px;
+}
+.flow-step p {
+  margin: 0;
+  color: var(--ink-dim);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
 .about-steps {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -1096,6 +1165,8 @@ body.hide-coords .square .coord { display: none; }
   .topbar { padding: 18px 20px; }
   .about { padding: 32px 20px 80px; }
   .about-hero { grid-template-columns: 1fr; gap: 28px; margin-bottom: 48px; }
+  .architecture-copy h3 { font-size: 32px; }
+  .flow-grid { grid-template-columns: 1fr; }
   .about-steps { grid-template-columns: 1fr; }
   .history { padding: 32px 20px 80px; }
 }

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,5 +1,28 @@
 import { Link } from "react-router-dom";
 
+const FLOW = [
+  {
+    num: "01",
+    title: "Start a session",
+    body: "React opens a WebSocket and sends the selected time control and side. FastAPI creates a game record, starts server-owned clocks, and subscribes the socket to that game.",
+  },
+  {
+    num: "02",
+    title: "Play a move",
+    body: "The board uses chess.js for local move rules and instant feedback. When you move, the client sends the new FEN, SAN, and square data to the backend.",
+  },
+  {
+    num: "03",
+    title: "Let the engine think",
+    body: "FastAPI stores the player move, updates clock state, then runs the minimax engine off the event loop so the WebSocket stays responsive.",
+  },
+  {
+    num: "04",
+    title: "Reply and remember",
+    body: "The AI move comes back over WebSocket with clock updates. When the game ends, moves are finalized to PGN and saved for the History and Replay pages.",
+  },
+];
+
 const STEPS = [
   {
     num: "01",
@@ -101,7 +124,42 @@ export default function About() {
       </section>
 
       <section className="about-block">
-        <div className="section-label">How it works</div>
+        <div className="section-label">Architecture</div>
+        <div className="architecture-copy">
+          <h3>A small real-time system around a chess engine.</h3>
+          <p>
+            Gambitron keeps the board fast in the browser and moves the expensive work to the
+            backend. The client handles interaction and legal-move hints; FastAPI owns game
+            sessions, clocks, AI turns, and persistence.
+          </p>
+        </div>
+
+        <figure className="architecture-figure">
+          <img
+            src="/gambitron-architecture.svg"
+            alt="Gambitron architecture diagram showing the React client, FastAPI backend, minimax engine, timers, PostgreSQL, and replay flow"
+          />
+          <figcaption>
+            <span>Editable Draw.io source</span>
+            <a href="/gambitron-architecture.drawio" download>
+              Download .drawio
+            </a>
+          </figcaption>
+        </figure>
+
+        <div className="flow-grid" aria-label="Application flow">
+          {FLOW.map((s) => (
+            <article key={s.num} className="flow-step">
+              <div className="step-num">{s.num}</div>
+              <h3>{s.title}</h3>
+              <p>{s.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="about-block">
+        <div className="section-label">How to play</div>
         <div className="about-steps">
           {STEPS.map((s) => (
             <article key={s.num} className="step">


### PR DESCRIPTION
## Summary

- Adds a clean architecture section to the About page explaining the React client, FastAPI backend, engine, timer, PostgreSQL, and replay flow.
- Adds an SVG architecture diagram plus editable Draw.io source under `frontend/public`.
- Updates the README "How It Works" section with the same diagram and a clearer system overview.

## Impact

This gives visitors and contributors a simple visual model of how live play, AI moves, server-owned clocks, persistence, and replay fit together.

## Validation

- `python3 -m xml.etree.ElementTree frontend/public/gambitron-architecture.svg`
- `python3 -m xml.etree.ElementTree frontend/public/gambitron-architecture.drawio`
- `npm ci`
- `npm run build`
- `npm run lint` (passes with 3 existing warnings unrelated to this change)
