### PR TITLE
fix: implement server clock increments

### DIFF
--- a/backend/db/games.py
+++ b/backend/db/games.py
@@ -1,4 +1,5 @@
 """Game CRUD operations."""
+import json
 import uuid
 
 from db.connection import get_pool
@@ -7,27 +8,31 @@ from db.connection import get_pool
 _memory_games: dict[uuid.UUID, dict] = {}
 
 
-async def create_game(time_control_ms: int, player_color: str) -> uuid.UUID:
+async def create_game(time_control_ms: int, player_color: str, increment_ms: int = 0) -> uuid.UUID:
     """Create a new game. Returns game_id. Uses in-memory when DB unavailable (local dev)."""
     pool = get_pool()
     if not pool:
         gid = uuid.uuid4()
+        metadata = {"increment_ms": increment_ms}
         _memory_games[gid] = {
             "id": gid,
             "time_control_ms": time_control_ms,
+            "increment_ms": increment_ms,
             "player_color": player_color,
             "ended_at": None,
+            "metadata": metadata,
         }
         return gid
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            INSERT INTO games (time_control_ms, player_color)
-            VALUES ($1, $2)
+            INSERT INTO games (time_control_ms, player_color, metadata)
+            VALUES ($1, $2, $3::jsonb)
             RETURNING id
             """,
             time_control_ms,
             player_color,
+            json.dumps({"increment_ms": increment_ms}),
         )
         return row["id"]
 

--- a/backend/test_timers.py
+++ b/backend/test_timers.py
@@ -1,0 +1,136 @@
+"""Regression tests for server-authoritative clock increments."""
+import asyncio
+import uuid
+
+from websocket import handlers
+from websocket import timers as timers_module
+
+
+START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+AFTER_E4_FEN = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+AFTER_E4_E5_FEN = "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2"
+
+
+def setup_function():
+    timers_module._game_timers.clear()
+
+
+def teardown_function():
+    timers_module._game_timers.clear()
+
+
+def test_add_player_increment_uses_registered_increment():
+    game_id = uuid.uuid4()
+
+    timers_module.register_game(game_id, 120_000, "white", START_FEN, increment_ms=1_000)
+    timers_module.add_player_increment(game_id)
+
+    timer = timers_module.get_timer(game_id)
+    assert timer is not None
+    assert timer["player_time_ms"] == 121_000
+    assert timer["ai_time_ms"] == 120_000
+
+
+def test_start_game_registers_increment(monkeypatch):
+    game_id = uuid.uuid4()
+
+    async def fake_create_game(time_control_ms: int, player_color: str, increment_ms: int = 0):
+        assert time_control_ms == 180_000
+        assert player_color == "white"
+        assert increment_ms == 2_000
+        return game_id
+
+    monkeypatch.setattr(handlers.games_db, "create_game", fake_create_game)
+    monkeypatch.setattr(handlers.connection_manager, "subscribe", lambda ws, gid: None)
+
+    response = asyncio.run(
+        handlers.handle_start_game(
+            object(),
+            {"type": "start_game", "timeControlMs": 180_000, "incrementMs": 2_000, "playerColor": "white"},
+        )
+    )
+
+    timer = timers_module.get_timer(game_id)
+    assert response is not None
+    assert response["incrementMs"] == 2_000
+    assert timer is not None
+    assert timer["increment_ms"] == 2_000
+
+
+def test_player_move_adds_increment_for_both_completed_moves(monkeypatch):
+    game_id = uuid.uuid4()
+    appended_moves: list[dict] = []
+
+    timers_module.register_game(game_id, 120_000, "white", START_FEN, increment_ms=1_000)
+
+    async def fake_get_game(gid: uuid.UUID):
+        assert gid == game_id
+        return {"id": gid, "player_color": "white", "ended_at": None}
+
+    async def fake_get_move_count(gid: uuid.UUID):
+        assert gid == game_id
+        return len(appended_moves)
+
+    async def fake_append_move(
+        gid: uuid.UUID,
+        ply: int,
+        fen: str,
+        san: str,
+        from_square: str | None = None,
+        to_square: str | None = None,
+        captured: str | None = None,
+    ):
+        appended_moves.append(
+            {
+                "ply": ply,
+                "fen": fen,
+                "san": san,
+                "from_square": from_square,
+                "to_square": to_square,
+                "captured": captured,
+            }
+        )
+        return True
+
+    async def fake_get_moves_by_game(gid: uuid.UUID):
+        assert gid == game_id
+        return appended_moves
+
+    async def fake_run_ai(fen: str):
+        assert fen == AFTER_E4_FEN
+        return {
+            "updated_fen": AFTER_E4_E5_FEN,
+            "result": "*",
+            "san": "e5",
+            "from_square": "e7",
+            "to_square": "e5",
+            "captured": None,
+        }
+
+    monkeypatch.setattr(handlers.games_db, "get_game", fake_get_game)
+    monkeypatch.setattr(handlers.moves_db, "get_move_count", fake_get_move_count)
+    monkeypatch.setattr(handlers.moves_db, "append_move", fake_append_move)
+    monkeypatch.setattr(handlers.moves_db, "get_moves_by_game", fake_get_moves_by_game)
+    monkeypatch.setattr(handlers, "_run_ai", fake_run_ai)
+    monkeypatch.setattr(handlers.connection_manager, "subscribe", lambda ws, gid: None)
+
+    response = asyncio.run(
+        handlers.handle_player_move(
+            object(),
+            {
+                "type": "player_move",
+                "gameId": str(game_id),
+                "fen": AFTER_E4_FEN,
+                "san": "e4",
+                "from": "e2",
+                "to": "e4",
+            },
+        )
+    )
+
+    timer = timers_module.get_timer(game_id)
+    assert response is not None
+    assert response["type"] == "ai_move"
+    assert timer is not None
+    assert timer["player_time_ms"] == 121_000
+    assert timer["ai_time_ms"] == 121_000

--- a/backend/websocket/handlers.py
+++ b/backend/websocket/handlers.py
@@ -134,25 +134,41 @@ def _validate_player_move(
     )
 
 
+def _coerce_increment_ms(value) -> int | None:
+    """Return a sanitized non-negative increment, or None for invalid input."""
+    if value is None:
+        return 0
+    if not isinstance(value, (int, float)):
+        return None
+    value = int(value)
+    if value < 0:
+        return None
+    return value
+
+
 async def handle_start_game(ws: WebSocket, data: dict) -> dict | None:
     """Handle start_game. Returns response to send."""
     time_control_ms = data.get("timeControlMs")
+    increment_ms = _coerce_increment_ms(data.get("incrementMs"))
     player_color = data.get("playerColor", "white")
     if time_control_ms is None or not isinstance(time_control_ms, (int, float)):
         return {"type": "error", "message": "timeControlMs required"}
+    if increment_ms is None:
+        return {"type": "error", "message": "incrementMs must be a non-negative number"}
     time_control_ms = int(time_control_ms)
     if player_color not in ("white", "black"):
         player_color = "white"
 
-    game_id = await games_db.create_game(time_control_ms, player_color)
+    game_id = await games_db.create_game(time_control_ms, player_color, increment_ms)
     fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-    timers_module.register_game(game_id, time_control_ms, player_color, fen)
+    timers_module.register_game(game_id, time_control_ms, player_color, fen, increment_ms)
     connection_manager.subscribe(ws, game_id)
     return {
         "type": "game_started",
         "gameId": str(game_id),
         "fen": fen,
         "timeControlMs": time_control_ms,
+        "incrementMs": increment_ms,
         "playerTimeMs": time_control_ms,
         "aiTimeMs": time_control_ms,
     }
@@ -228,6 +244,7 @@ async def handle_player_move(ws: WebSocket, data: dict) -> dict | None:
         timers_module.clear_player_first_move_pending(game_id)
 
     await moves_db.append_move(game_id, player_ply, fen, san, from_sq, to_sq, player_captured)
+    timers_module.add_player_increment(game_id)
 
     # Check for draw by 3-move repetition after player move
     all_moves = await moves_db.get_moves_by_game(game_id)
@@ -257,6 +274,20 @@ async def handle_player_move(ws: WebSocket, data: dict) -> dict | None:
 
     ai_result = await _run_ai(fen)
     times = timers_module.apply_elapsed(game_id)
+    if times:
+        pt, at = times
+        t = timers_module.get_timer(game_id)
+        if t and not timers_module.is_player_turn(t["fen"], player_color) and at <= 0:
+            timers_module.mark_ended(game_id)
+            timers_module.remove_game(game_id)
+            timeout_result = "1-0" if player_color == "white" else "0-1"
+            await moves_db.finalize_game_to_pgn(game_id, timeout_result, "timeout", player_color)
+            return {
+                "type": "game_ended",
+                "gameId": str(game_id),
+                "result": timeout_result,
+                "termination": "timeout",
+            }
     updated_fen = ai_result["updated_fen"]
     result = ai_result["result"]
 
@@ -268,6 +299,7 @@ async def handle_player_move(ws: WebSocket, data: dict) -> dict | None:
     await moves_db.append_move(game_id, ai_ply, updated_fen, ai_san, ai_from, ai_to, ai_captured)
 
     timers_module.update_fen(game_id, updated_fen)
+    timers_module.add_ai_increment(game_id)
 
     # Check for draw by 3-move repetition after AI move
     all_moves = await moves_db.get_moves_by_game(game_id)
@@ -367,6 +399,7 @@ async def handle_request_ai_move(ws: WebSocket, data: dict) -> dict | None:
 
     timers_module.update_fen(game_id, updated_fen)
     timers_module.clear_ai_first_move_pending(game_id)
+    timers_module.add_ai_increment(game_id)
 
     # Check for draw by 3-move repetition after AI move
     all_moves = await moves_db.get_moves_by_game(game_id)
@@ -461,6 +494,7 @@ async def handle_subscribe(ws: WebSocket, data: dict) -> dict | None:
             "playerTimeMs": t["player_time_ms"],
             "aiTimeMs": t["ai_time_ms"],
             "timeControlMs": time_control_ms,
+            "incrementMs": t.get("increment_ms", 0),
             "playerColor": player_color,
         }
 

--- a/backend/websocket/test_handlers.py
+++ b/backend/websocket/test_handlers.py
@@ -12,14 +12,34 @@ import pytest
 @pytest.fixture(autouse=True)
 def cleanup_handler_modules():
     yield
-    for module_name in ("websocket.handlers", "websocket.timers"):
+    for module_name in ("websocket.handlers", "websocket.timers", "db.games", "db.moves"):
         sys.modules.pop(module_name, None)
+    websocket_module = sys.modules.get("websocket")
+    if websocket_module:
+        for attr in ("handlers", "timers"):
+            if hasattr(websocket_module, attr):
+                delattr(websocket_module, attr)
+    db_module = sys.modules.get("db")
+    if db_module:
+        for attr in ("games", "moves"):
+            if hasattr(db_module, attr):
+                delattr(db_module, attr)
 
 
 def _load_handlers(monkeypatch):
     """Load handlers with DB modules stubbed for pure handler tests."""
-    for module_name in ("websocket.handlers", "websocket.timers"):
+    for module_name in ("websocket.handlers", "websocket.timers", "db.games", "db.moves"):
         sys.modules.pop(module_name, None)
+    websocket_module = sys.modules.get("websocket")
+    if websocket_module:
+        for attr in ("handlers", "timers"):
+            if hasattr(websocket_module, attr):
+                delattr(websocket_module, attr)
+    db_module = sys.modules.get("db")
+    if db_module:
+        for attr in ("games", "moves"):
+            if hasattr(db_module, attr):
+                delattr(db_module, attr)
 
     games: dict[uuid.UUID, dict] = {}
     appended_moves: list[dict] = []
@@ -71,10 +91,11 @@ def _load_handlers(monkeypatch):
         board = chess.Board(fen)
         return (player_color == "white") == (board.turn == chess.WHITE)
 
-    def register_game(game_id, time_control_ms, player_color, fen):
+    def register_game(game_id, time_control_ms, player_color, fen, increment_ms=0):
         timers_state[game_id] = {
             "player_time_ms": time_control_ms,
             "ai_time_ms": time_control_ms,
+            "increment_ms": increment_ms,
             "player_color": player_color,
             "fen": fen,
             "game_ended": False,
@@ -96,6 +117,18 @@ def _load_handlers(monkeypatch):
     def clear_player_first_move_pending(game_id):
         timers_state[game_id]["player_first_move_pending"] = False
 
+    def add_player_increment(game_id):
+        timer = timers_state.get(game_id)
+        if timer:
+            timer["player_time_ms"] += timer.get("increment_ms", 0)
+        return timer["player_time_ms"], timer["ai_time_ms"]
+
+    def add_ai_increment(game_id):
+        timer = timers_state.get(game_id)
+        if timer:
+            timer["ai_time_ms"] += timer.get("increment_ms", 0)
+        return timer["player_time_ms"], timer["ai_time_ms"]
+
     def mark_ended(game_id):
         timers_state[game_id]["game_ended"] = True
 
@@ -110,6 +143,8 @@ def _load_handlers(monkeypatch):
         apply_elapsed=apply_elapsed,
         update_fen=update_fen,
         clear_player_first_move_pending=clear_player_first_move_pending,
+        add_player_increment=add_player_increment,
+        add_ai_increment=add_ai_increment,
         mark_ended=mark_ended,
         remove_game=remove_game,
     )

--- a/backend/websocket/timers.py
+++ b/backend/websocket/timers.py
@@ -26,13 +26,16 @@ def register_game(
     time_control_ms: int,
     player_color: str,
     fen: str,
+    increment_ms: int = 0,
 ) -> None:
     """Register a new game with timer. Both clocks start at time_control_ms.
     ai_first_move_pending: when player is black, AI moves first - don't tick until AI has moved.
     player_first_move_pending: when player is white, don't tick player clock until they move."""
+    increment_ms = max(0, int(increment_ms))
     _game_timers[game_id] = {
         "player_time_ms": time_control_ms,
         "ai_time_ms": time_control_ms,
+        "increment_ms": increment_ms,
         "last_tick_ts": time.time(),
         "player_color": player_color,
         "fen": fen,
@@ -76,6 +79,27 @@ def update_fen(game_id: uuid.UUID, fen: str) -> None:
     t = _game_timers.get(game_id)
     if t and not t.get("game_ended"):
         t["fen"] = fen
+
+
+def _add_increment(game_id: uuid.UUID, clock_key: str) -> tuple[int, int] | None:
+    """Add the configured increment to one side's clock after a completed move."""
+    t = _game_timers.get(game_id)
+    if not t or t.get("game_ended"):
+        return None
+    increment_ms = t.get("increment_ms", 0)
+    if increment_ms > 0:
+        t[clock_key] += increment_ms
+    return (t["player_time_ms"], t["ai_time_ms"])
+
+
+def add_player_increment(game_id: uuid.UUID) -> tuple[int, int] | None:
+    """Add the configured increment after the human player completes a move."""
+    return _add_increment(game_id, "player_time_ms")
+
+
+def add_ai_increment(game_id: uuid.UUID) -> tuple[int, int] | None:
+    """Add the configured increment after the AI completes a move."""
+    return _add_increment(game_id, "ai_time_ms")
 
 
 def clear_ai_first_move_pending(game_id: uuid.UUID) -> None:

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -33,15 +33,17 @@ function computeResult(game: Chess): string {
 export interface UseGameOptions {
   gameId: string | null;
   initialMinutes?: number;
+  initialIncrementSeconds?: number;
   initialColor?: PlayerColor;
-  initialGameState?: { fen: string; timeControlMs: number; playerColor: PlayerColor };
-  onGameCreated?: (gameId: string, gameState: { fen: string; timeControlMs: number; playerColor: PlayerColor }) => void;
+  initialGameState?: { fen: string; timeControlMs: number; incrementMs?: number; playerColor: PlayerColor };
+  onGameCreated?: (gameId: string, gameState: { fen: string; timeControlMs: number; incrementMs?: number; playerColor: PlayerColor }) => void;
 }
 
 export function useGame(options?: UseGameOptions) {
   const {
     gameId = null,
     initialMinutes = 5,
+    initialIncrementSeconds = 0,
     initialColor,
     initialGameState,
     onGameCreated,
@@ -74,6 +76,9 @@ export function useGame(options?: UseGameOptions) {
 
   const [startOpen, setStartOpen] = useState(!initialColor && !initialGameState);
   const [selectedMinutes] = useState(initialMinutes);
+  const [selectedIncrementMs] = useState(() =>
+    initialGameState?.incrementMs ?? Math.max(0, initialIncrementSeconds * 1000)
+  );
   const [playerColor, setPlayerColor] = useState<PlayerColor>(initialColor ?? initialGameState?.playerColor ?? "white");
 
   const [fenInput, setFenInput] = useState("");
@@ -83,13 +88,11 @@ export function useGame(options?: UseGameOptions) {
   const wsRef = useRef<WebSocket | null>(null);
   const socketControllerRef = useRef<ReturnType<typeof createReconnectingSocket> | null>(null);
   const currentGameIdRef = useRef<string | null>(gameId);
-  const pendingStartRef = useRef<{ minutes: number; color: PlayerColor } | null>(null);
+  const pendingStartRef = useRef<{ minutes: number; incrementMs: number; color: PlayerColor } | null>(null);
   const playerColorRef = useRef<PlayerColor>("white");
   const onGameCreatedRef = useRef(onGameCreated);
-  const aiThinkingRef = useRef(false);
   onGameCreatedRef.current = onGameCreated;
   playerColorRef.current = playerColor;
-  aiThinkingRef.current = aiThinking;
 
   const apiBase = useMemo(() => `${import.meta.env.VITE_backend}`, []);
 
@@ -109,6 +112,11 @@ export function useGame(options?: UseGameOptions) {
     socketControllerRef.current?.close();
     socketControllerRef.current = null;
     wsRef.current = null;
+  }, []);
+
+  const syncServerTimes = useCallback((playerMs: number, aiMs: number) => {
+    setPlayerTimeMs(playerMs);
+    setAiTimeMs(aiMs);
   }, []);
 
   const callAIViaRest = useCallback(
@@ -423,7 +431,7 @@ export function useGame(options?: UseGameOptions) {
       setPlayerHasMoved(false);
       setGameEnded(false);
       setGameStarted(true);
-      pendingStartRef.current = { minutes, color };
+      pendingStartRef.current = { minutes, incrementMs: selectedIncrementMs, color };
 
       socketControllerRef.current?.close();
       const controller = createReconnectingSocket(
@@ -434,8 +442,7 @@ export function useGame(options?: UseGameOptions) {
             currentGameIdRef.current = m.gameId;
             pendingStartRef.current = null;
             playerColorRef.current = pc;
-            setPlayerTimeMs(m.playerTimeMs ?? m.timeControlMs);
-            setAiTimeMs(m.aiTimeMs ?? m.timeControlMs);
+            syncServerTimes(m.playerTimeMs ?? m.timeControlMs, m.aiTimeMs ?? m.timeControlMs);
             setInitialTimeMs(m.timeControlMs);
             setMoveHistory([]);
             try {
@@ -449,6 +456,7 @@ export function useGame(options?: UseGameOptions) {
             onGameCreatedRef.current?.(m.gameId, {
               fen: m.fen,
               timeControlMs: m.timeControlMs,
+              incrementMs: m.incrementMs,
               playerColor: pc,
             });
             if (pc === "black") {
@@ -465,17 +473,7 @@ export function useGame(options?: UseGameOptions) {
             playerColorRef.current = m.playerColor;
             setInitialTimeMs(m.timeControlMs);
             setPlayerColor(m.playerColor);
-            if (aiThinkingRef.current) {
-              setAiTimeMs(m.aiTimeMs);
-            } else {
-              const currentTurn = chess.turn();
-              const pt = m.playerColor === "white" ? "w" : "b";
-              if (currentTurn === pt) {
-                setPlayerTimeMs(m.playerTimeMs);
-              } else {
-                setAiTimeMs(m.aiTimeMs);
-              }
-            }
+            syncServerTimes(m.playerTimeMs, m.aiTimeMs);
             if (m.fen) {
               try {
                 chess.load(m.fen);
@@ -525,18 +523,7 @@ export function useGame(options?: UseGameOptions) {
           } else if (msg.type === "time_update") {
             const m = msg as TimeUpdateMessage;
             if (m.gameId === currentGameIdRef.current) {
-              if (aiThinkingRef.current) {
-                setAiTimeMs(m.aiTimeMs);
-              } else {
-                const currentTurn = chess.turn();
-                const pc = playerColorRef.current;
-                const pt = pc === "white" ? "w" : "b";
-                if (currentTurn === pt) {
-                  setPlayerTimeMs(m.playerTimeMs);
-                } else {
-                  setAiTimeMs(m.aiTimeMs);
-                }
-              }
+              syncServerTimes(m.playerTimeMs, m.aiTimeMs);
             }
           } else if (msg.type === "error") {
             setAiThinking(false);
@@ -555,6 +542,7 @@ export function useGame(options?: UseGameOptions) {
               sendMessage(ws!, {
                 type: "start_game",
                 timeControlMs: p.minutes * 60 * 1000,
+                incrementMs: p.incrementMs,
                 playerColor: p.color,
               });
             }
@@ -566,11 +554,11 @@ export function useGame(options?: UseGameOptions) {
       );
       socketControllerRef.current = controller;
     },
-    [chess, openEndgame]
+    [chess, openEndgame, selectedIncrementMs, syncServerTimes]
   );
 
   const connectToExistingGame = useCallback(
-    (gid: string, gameState?: { fen: string; timeControlMs: number; playerColor: PlayerColor }) => {
+    (gid: string, gameState?: { fen: string; timeControlMs: number; incrementMs?: number; playerColor: PlayerColor }) => {
       if (wsRef.current?.readyState === WebSocket.OPEN && currentGameIdRef.current === gid) {
         return;
       }
@@ -609,17 +597,7 @@ export function useGame(options?: UseGameOptions) {
             playerColorRef.current = m.playerColor;
             setInitialTimeMs(m.timeControlMs);
             setPlayerColor(m.playerColor);
-            if (aiThinkingRef.current) {
-              setAiTimeMs(m.aiTimeMs);
-            } else {
-              const currentTurn = chess.turn();
-              const pt = m.playerColor === "white" ? "w" : "b";
-              if (currentTurn === pt) {
-                setPlayerTimeMs(m.playerTimeMs);
-              } else {
-                setAiTimeMs(m.aiTimeMs);
-              }
-            }
+            syncServerTimes(m.playerTimeMs, m.aiTimeMs);
             if (m.fen) {
               try {
                 chess.load(m.fen);
@@ -635,18 +613,7 @@ export function useGame(options?: UseGameOptions) {
           } else if (msg.type === "time_update") {
             const m = msg as TimeUpdateMessage;
             if (m.gameId === gid) {
-              if (aiThinkingRef.current) {
-                setAiTimeMs(m.aiTimeMs);
-              } else {
-                const currentTurn = chess.turn();
-                const pc = playerColorRef.current;
-                const pt = pc === "white" ? "w" : "b";
-                if (currentTurn === pt) {
-                  setPlayerTimeMs(m.playerTimeMs);
-                } else {
-                  setAiTimeMs(m.aiTimeMs);
-                }
-              }
+              syncServerTimes(m.playerTimeMs, m.aiTimeMs);
             }
           } else if (msg.type === "ai_move") {
             const m = msg as AIMoveMessage;
@@ -698,7 +665,7 @@ export function useGame(options?: UseGameOptions) {
       );
       socketControllerRef.current = controller;
     },
-    [chess, openEndgame]
+    [chess, openEndgame, syncServerTimes]
   );
 
   const loadFenAndMaybeAI = useCallback(

--- a/frontend/src/lib/websocket.ts
+++ b/frontend/src/lib/websocket.ts
@@ -3,6 +3,7 @@
 export interface StartGamePayload {
   type: "start_game";
   timeControlMs: number;
+  incrementMs?: number;
   playerColor: "white" | "black";
 }
 
@@ -54,6 +55,7 @@ export interface GameStartedMessage {
   gameId: string;
   fen: string;
   timeControlMs: number;
+  incrementMs?: number;
   playerTimeMs?: number;
   aiTimeMs?: number;
 }
@@ -72,6 +74,7 @@ export interface GameStateMessage {
   playerTimeMs: number;
   aiTimeMs: number;
   timeControlMs: number;
+  incrementMs?: number;
   playerColor: "white" | "black";
   result?: string;
   termination?: string;

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -2,14 +2,14 @@ import { useState } from "react";
 import { useHistory } from "react-router-dom";
 
 const TIME_MODES = [
-  { id: "1+0",   cat: "Bullet",    val: "1+0",   minutes: 1,  sub: "1 min" },
-  { id: "2+1",   cat: "Bullet",    val: "2+1",   minutes: 2,  sub: "2 min · +1s" },
-  { id: "3+0",   cat: "Blitz",     val: "3+0",   minutes: 3,  sub: "3 min" },
-  { id: "3+2",   cat: "Blitz",     val: "3+2",   minutes: 3,  sub: "3 min · +2s" },
-  { id: "5+0",   cat: "Blitz",     val: "5+0",   minutes: 5,  sub: "5 min" },
-  { id: "10+0",  cat: "Rapid",     val: "10+0",  minutes: 10, sub: "10 min" },
-  { id: "15+10", cat: "Rapid",     val: "15+10", minutes: 15, sub: "15 min · +10s" },
-  { id: "30+0",  cat: "Classical", val: "30+0",  minutes: 30, sub: "30 min" },
+  { id: "1+0",   cat: "Bullet",    val: "1+0",   minutes: 1,  increment: 0,  sub: "1 min" },
+  { id: "2+1",   cat: "Bullet",    val: "2+1",   minutes: 2,  increment: 1,  sub: "2 min · +1s" },
+  { id: "3+0",   cat: "Blitz",     val: "3+0",   minutes: 3,  increment: 0,  sub: "3 min" },
+  { id: "3+2",   cat: "Blitz",     val: "3+2",   minutes: 3,  increment: 2,  sub: "3 min · +2s" },
+  { id: "5+0",   cat: "Blitz",     val: "5+0",   minutes: 5,  increment: 0,  sub: "5 min" },
+  { id: "10+0",  cat: "Rapid",     val: "10+0",  minutes: 10, increment: 0,  sub: "10 min" },
+  { id: "15+10", cat: "Rapid",     val: "15+10", minutes: 15, increment: 10, sub: "15 min · +10s" },
+  { id: "30+0",  cat: "Classical", val: "30+0",  minutes: 30, increment: 0,  sub: "30 min" },
 ];
 
 export default function Landing() {
@@ -25,7 +25,7 @@ export default function Landing() {
     } else {
       color = side === "w" ? "white" : "black";
     }
-    history.push(`/play/new?minutes=${mode.minutes}&color=${color}`);
+    history.push(`/play/new?minutes=${mode.minutes}&increment=${mode.increment}&color=${color}`);
   }
 
   return (

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -46,18 +46,25 @@ export default function Play() {
   const minutesParam = search.get("minutes");
   const parsed = minutesParam ? parseInt(minutesParam, 10) : NaN;
   const initialMinutes = VALID_MINUTES.includes(parsed) ? parsed : 5;
+  const incrementParam = search.get("increment");
+  const parsedIncrement = incrementParam ? parseInt(incrementParam, 10) : NaN;
+  const initialIncrementSeconds =
+    Number.isInteger(parsedIncrement) && parsedIncrement >= 0 && parsedIncrement <= 60
+      ? parsedIncrement
+      : 0;
   const colorParam = search.get("color");
   const initialColor =
     colorParam === "white" || colorParam === "black" ? colorParam : undefined;
   const initialGameState = (
     location.state as {
-      gameState?: { fen: string; timeControlMs: number; playerColor: "white" | "black" };
+      gameState?: { fen: string; timeControlMs: number; incrementMs?: number; playerColor: "white" | "black" };
     }
   )?.gameState;
 
   const game = useGame({
     gameId: gameId ?? null,
     initialMinutes,
+    initialIncrementSeconds,
     initialColor,
     initialGameState,
     onGameCreated: (id, state) => {


### PR DESCRIPTION
## Summary
- Send `incrementMs` from the selected `m+i` time mode through the play route and websocket start payload.
- Store the increment in the server-authoritative timer and add it after each completed human or AI move.
- Sync both clock values from server updates so inactive clocks visibly receive increments.
- Add regression tests for increment registration and post-move clock updates, plus test shim updates for the newer server-side move validation tests.

## Test plan
- [x] `uv run --with pytest --with chess --with fastapi --with 'uvicorn[standard]' --with asyncpg pytest -q` (`22 passed`)
- [x] `npm run build`
- [x] `npm run lint` (passes with existing warnings)

## Notes
- Unrelated local edits in `README.md`, `frontend/src/index.css`, `frontend/src/pages/About.tsx`, and architecture assets were left out of this PR.
