### PR TITLE
feature: endgame sound, king highlights, and non-blocking game-over UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ server-key.pem
 
 # PGN game storage
 data/
+.gstack/
+
+# Python virtual environment
+backend/venv/
+
+# Local environment overrides
+frontend/.env.local

--- a/backend/db/connection.py
+++ b/backend/db/connection.py
@@ -1,4 +1,6 @@
 """PostgreSQL connection pool."""
+from __future__ import annotations
+
 import asyncpg
 
 from config import DATABASE_URL

--- a/backend/db/games.py
+++ b/backend/db/games.py
@@ -1,4 +1,6 @@
 """Game CRUD operations."""
+from __future__ import annotations
+
 import json
 import uuid
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,6 @@
 """Gambitron FastAPI backend."""
+from __future__ import annotations
+
 import asyncio
 import json
 import uuid

--- a/backend/websocket/timers.py
+++ b/backend/websocket/timers.py
@@ -1,4 +1,6 @@
 """Game timer state and tick logic. Backend owns clocks and detects timeouts."""
+from __future__ import annotations
+
 import time
 import uuid
 

--- a/frontend/src/components/ChessBoard.tsx
+++ b/frontend/src/components/ChessBoard.tsx
@@ -22,6 +22,7 @@ interface ChessBoardProps {
   onDragStart: (square: string) => void;
   onDropPiece: (from: string, to: string) => void;
   onDragEnd: () => void;
+  highlightedSquares?: Array<{ square: string; className: string }>;
 }
 
 export function ChessBoard({
@@ -40,6 +41,7 @@ export function ChessBoard({
   onDragStart,
   onDropPiece,
   onDragEnd,
+  highlightedSquares,
 }: ChessBoardProps) {
   const flipped = orientation === "black";
   const fileLabels = flipped ? [...HORIZONTAL].reverse() : HORIZONTAL;
@@ -66,6 +68,7 @@ export function ChessBoard({
           const isLastFrom = lastMove?.from === squareName;
           const isLastTo = lastMove?.to === squareName;
           const hasPiece = !!piece;
+          const highlight = highlightedSquares?.find((h) => h.square === squareName);
 
           const showFile = flipped ? rowIdx === 0 : rowIdx === 7;
           const showRank = flipped ? colIdx === 7 : colIdx === 0;
@@ -77,6 +80,7 @@ export function ChessBoard({
             isLastFrom ? "last-from" : "",
             isLastTo ? "last-to" : "",
             hasPiece ? "has-piece" : "",
+            highlight?.className ?? "",
           ]
             .filter(Boolean)
             .join(" ");

--- a/frontend/src/components/Dialogs.tsx
+++ b/frontend/src/components/Dialogs.tsx
@@ -6,11 +6,6 @@ interface DialogsProps {
   onPromotionClose: () => void;
   onPromotionPick: (piece: "q" | "r" | "b" | "n") => void;
   playerColor: PlayerColor;
-  endgameOpen: boolean;
-  endgameResult: string;
-  endgameReason: string;
-  onEndgameClose: () => void;
-  onNewGameFromEndgame: () => void;
   errorOpen: boolean;
   errorMessage: string;
   onErrorClose: () => void;
@@ -30,11 +25,6 @@ export function Dialogs({
   onPromotionClose,
   onPromotionPick,
   playerColor,
-  endgameOpen,
-  endgameResult,
-  endgameReason,
-  onEndgameClose,
-  onNewGameFromEndgame,
   errorOpen,
   errorMessage,
   onErrorClose,
@@ -53,27 +43,8 @@ export function Dialogs({
     }
   }, [errorOpen, onErrorClose]);
 
-  const playerWins =
-    (endgameResult === "1-0" && playerColor === "white") ||
-    (endgameResult === "0-1" && playerColor === "black");
-  const playerLoses =
-    (endgameResult === "0-1" && playerColor === "white") ||
-    (endgameResult === "1-0" && playerColor === "black");
-
-  const headline = playerWins ? "Victory" : playerLoses ? "Defeat" : "Drawn";
-
-  const reasonText = (() => {
-    if (playerWins && endgameReason === "checkmate") return "Checkmate · you outplayed Gambitron";
-    if (playerWins && endgameReason === "timeout") return "Gambitron ran out of time";
-    if (playerLoses && endgameReason === "checkmate") return "Checkmate · Gambitron got you";
-    if (playerLoses && endgameReason === "timeout") return "You ran out of time";
-    if (endgameResult === "1/2-1/2") return "The game ends in a draw";
-    return endgameReason || "Game over";
-  })();
-
   return (
     <>
-      {/* Promotion */}
       {promotionOpen && (
         <div className="modal-overlay" onClick={onPromotionClose}>
           <div className="modal grain" onClick={(e) => e.stopPropagation()} style={{ paddingBottom: 28 }}>
@@ -99,25 +70,6 @@ export function Dialogs({
         </div>
       )}
 
-      {/* Endgame result */}
-      {endgameOpen && (
-        <div className="modal-overlay">
-          <div className="modal grain">
-            <h3>
-              {playerWins ? <em>{headline}.</em> : <span>{headline}.</span>}
-            </h3>
-            <div className="reason">{reasonText}</div>
-            <div className="modal-actions">
-              <button type="button" onClick={onEndgameClose}>Exit</button>
-              <button type="button" className="primary" onClick={onNewGameFromEndgame}>
-                New Game
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Error toast */}
       {errorOpen && (
         <div
           className="error-toast"

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { Chess, Square } from "chess.js";
-import { playMoveSound } from "@/utils/sounds";
+import { playMoveSound, playCheckmateSound } from "@/utils/sounds";
 import {
   createReconnectingSocket,
   sendMessage,
@@ -28,6 +28,22 @@ function computeResult(game: Chess): string {
     return winner === "w" ? "1-0" : "0-1";
   }
   return "1/2-1/2";
+}
+
+function findKingSquares(game: Chess, color: "w" | "b"): string[] {
+  const squares: string[] = [];
+  const board = game.board();
+  for (let row = 0; row < 8; row++) {
+    for (let col = 0; col < 8; col++) {
+      const piece = board[row][col];
+      if (piece && piece.type === "k" && piece.color === color) {
+        const file = "abcdefgh"[col];
+        const rank = String(8 - row);
+        squares.push(`${file}${rank}`);
+      }
+    }
+  }
+  return squares;
 }
 
 export interface UseGameOptions {
@@ -66,6 +82,10 @@ export function useGame(options?: UseGameOptions) {
   const [pendingPromotionFrom, setPendingPromotionFrom] = useState<string | null>(null);
   const [pendingPromotionTo, setPendingPromotionTo] = useState<string | null>(null);
 
+  const [checkmatedKingSquare, setCheckmatedKingSquare] = useState<string | null>(null);
+
+  const [highlightedSquares, setHighlightedSquares] = useState<Array<{ square: string; className: string }>>([]);
+
   const [playerTimeMs, setPlayerTimeMs] = useState(START_TIME_MS);
   const [aiTimeMs, setAiTimeMs] = useState(START_TIME_MS);
   const [initialTimeMs, setInitialTimeMs] = useState(START_TIME_MS);
@@ -91,6 +111,7 @@ export function useGame(options?: UseGameOptions) {
   const pendingStartRef = useRef<{ minutes: number; incrementMs: number; color: PlayerColor } | null>(null);
   const playerColorRef = useRef<PlayerColor>("white");
   const onGameCreatedRef = useRef(onGameCreated);
+  const endgameTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   onGameCreatedRef.current = onGameCreated;
   playerColorRef.current = playerColor;
 
@@ -100,18 +121,40 @@ export function useGame(options?: UseGameOptions) {
   const aiTurn = playerColor === "white" ? "b" : "w";
 
   const openEndgame = useCallback((result: string, reason: string) => {
+    if (endgameTimerRef.current) {
+      clearTimeout(endgameTimerRef.current);
+      endgameTimerRef.current = null;
+    }
+    if (result === "1/2-1/2") {
+      const wKings = findKingSquares(chess, "w");
+      const bKings = findKingSquares(chess, "b");
+      setHighlightedSquares(
+        [...wKings, ...bKings].map((s) => ({ square: s, className: "drawn-king" }))
+      );
+    } else if (reason === "checkmate" || chess.isCheckmate()) {
+      playCheckmateSound();
+      const losingColor = chess.turn();
+      const squares = findKingSquares(chess, losingColor);
+      if (squares.length > 0) {
+        setCheckmatedKingSquare(squares[0]);
+        setHighlightedSquares(squares.map((s) => ({ square: s, className: "checkmated" })));
+      }
+    }
     setEndgameResult(result);
     setEndgameReason(reason);
-    setEndgameOpen(true);
     setGameEnded(true);
     setAiThinking(false);
     setGameStarted(false);
-  }, []);
+  }, [chess]);
 
   const closeSocket = useCallback(() => {
     socketControllerRef.current?.close();
     socketControllerRef.current = null;
     wsRef.current = null;
+    if (endgameTimerRef.current) {
+      clearTimeout(endgameTimerRef.current);
+      endgameTimerRef.current = null;
+    }
   }, []);
 
   const syncServerTimes = useCallback((playerMs: number, aiMs: number) => {
@@ -724,6 +767,9 @@ export function useGame(options?: UseGameOptions) {
     setGameStarted(false);
     setPlayerHasMoved(false);
     setGameEnded(false);
+    setEndgameOpen(false);
+    setCheckmatedKingSquare(null);
+    setHighlightedSquares([]);
     setStartOpen(true);
   }, [chess, closeSocket]);
 
@@ -740,12 +786,21 @@ export function useGame(options?: UseGameOptions) {
     setGameEnded(false);
     setAiThinking(false);
     setEndgameOpen(false);
+    setCheckmatedKingSquare(null);
     setStartOpen(true);
   }, [chess, closeSocket]);
 
   useEffect(() => {
     currentGameIdRef.current = gameId;
   }, [gameId]);
+
+  useEffect(() => {
+    return () => {
+      if (endgameTimerRef.current) {
+        clearTimeout(endgameTimerRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (gameId && gameId !== "new") {
@@ -860,6 +915,7 @@ export function useGame(options?: UseGameOptions) {
     VERTICAL,
     playerColor,
     gameEnded,
+    gameStarted,
     startOpen,
     onStartGame,
     promotionOpen,
@@ -883,6 +939,7 @@ export function useGame(options?: UseGameOptions) {
     aiTimeMs,
     initialTimeMs,
     isPlayersTurn,
+    aiThinking,
     handleNewGame,
     isAdmin,
     fenInput,
@@ -891,6 +948,8 @@ export function useGame(options?: UseGameOptions) {
     materialDiff,
     lastMove,
     moveHistory,
+    checkmatedKingSquare,
+    highlightedSquares,
     onLoadFen: () => {
       if (!fenInput.trim()) {
         setErrorMessage("Please enter a FEN string");

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { Chess, Square } from "chess.js";
-import { playMoveSound, playCheckmateSound } from "@/utils/sounds";
+import { playMoveSound, playWinSound, playLossSound } from "@/utils/sounds";
 import {
   createReconnectingSocket,
   sendMessage,
@@ -132,8 +132,12 @@ export function useGame(options?: UseGameOptions) {
         [...wKings, ...bKings].map((s) => ({ square: s, className: "drawn-king" }))
       );
     } else if (reason === "checkmate" || chess.isCheckmate()) {
-      playCheckmateSound();
       const losingColor = chess.turn();
+      const pc = playerColorRef.current;
+      const playerLost =
+        (losingColor === "w" && pc === "white") ||
+        (losingColor === "b" && pc === "black");
+      (playerLost ? playLossSound : playWinSound)();
       const squares = findKingSquares(chess, losingColor);
       if (squares.length > 0) {
         setCheckmatedKingSquare(squares[0]);

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -727,6 +727,9 @@ export function useGame(options?: UseGameOptions) {
         setGameStarted(true);
         setPlayerHasMoved(true);
       }
+      if (chess.isGameOver() && !gameEnded) {
+        openEndgame(computeResult(chess), chess.isCheckmate() ? "checkmate" : "draw");
+      }
       if (callAI && !chess.isGameOver() && !gameEnded && isAdmin && chess.turn() === aiTurn) {
         setAiThinking(true);
         try {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -522,6 +522,16 @@ a { color: inherit; text-decoration: none; }
   border-radius: 50%;
 }
 
+/* Checkmate king highlight — red tint */
+.square.checkmated { background: color-mix(in oklab, var(--accent), oklch(0.35 0.03 25) 60%); }
+.square.dark.checkmated { background: color-mix(in oklab, var(--accent-dim), oklch(0.2 0.02 15) 50%); }
+.square.checkmated::before { opacity: 0; }
+
+/* Draw king highlight — amber tint */
+.square.drawn-king { background: color-mix(in oklab, var(--board-light), oklch(0.72 0.12 85) 55%); }
+.square.dark.drawn-king { background: color-mix(in oklab, var(--board-dark), oklch(0.72 0.12 85) 45%); }
+.square.drawn-king::before { opacity: 0; }
+
 /* Board coordinates */
 .square .coord {
   position: absolute;
@@ -826,6 +836,75 @@ body.hide-coords .square .coord { display: none; }
   line-height: 1.7;
 }
 
+.architecture-copy {
+  max-width: 720px;
+  margin-bottom: 24px;
+}
+.architecture-copy h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 38px;
+  line-height: 1.05;
+  margin: 0 0 12px;
+}
+.architecture-copy p {
+  color: var(--ink-dim);
+  font-size: 15px;
+  line-height: 1.7;
+  margin: 0;
+}
+.architecture-figure {
+  margin: 0 0 28px;
+  border: 1px solid var(--line-soft);
+  background: var(--bg-elev);
+  overflow-x: auto;
+}
+.architecture-figure img {
+  display: block;
+  width: 100%;
+  min-width: 760px;
+  height: auto;
+}
+.architecture-figure figcaption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--line-soft);
+  padding: 12px 16px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+}
+.architecture-figure a {
+  color: var(--accent);
+}
+
+.flow-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--line-soft);
+  border: 1px solid var(--line-soft);
+}
+.flow-step {
+  background: var(--bg);
+  padding: 22px 20px 24px;
+}
+.flow-step h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  margin: 0 0 8px;
+}
+.flow-step p {
+  margin: 0;
+  color: var(--ink-dim);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
 .about-steps {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -933,6 +1012,62 @@ body.hide-coords .square .coord { display: none; }
   margin: 0 12px;
   letter-spacing: 0.1em;
 }
+
+/* ---------- Endgame banner (non-obstructive) ---------- */
+.endgame-banner-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 50;
+  pointer-events: none;
+  animation: endgameOverlayIn 1500ms ease-out both;
+}
+@keyframes endgameOverlayIn {
+  0% { opacity: 0; }
+  70% { opacity: 0; }
+  100% { opacity: 1; }
+}
+.endgame-banner {
+  pointer-events: auto;
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  padding: 28px 32px;
+  width: min(90vw, 340px);
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+.endgame-banner h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 38px;
+  letter-spacing: -0.02em;
+  margin: 0 0 2px;
+}
+.endgame-banner h3 em { color: var(--accent); font-style: italic; }
+.endgame-banner .reason {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 22px;
+}
+.endgame-banner .modal-actions { display: flex; gap: 10px; justify-content: center; }
+.endgame-banner .modal-actions button {
+  padding: 10px 20px;
+  border: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink);
+  background: none;
+  cursor: pointer;
+}
+.endgame-banner .modal-actions button.primary { background: var(--ink); color: #1a1a1a; border-color: var(--ink); }
+.endgame-banner .modal-actions button:hover { background: var(--bg-card); }
+.endgame-banner .modal-actions button.primary:hover { background: var(--accent); border-color: var(--accent); }
 
 /* ---------- Result modal ---------- */
 .modal-overlay {
@@ -1096,6 +1231,8 @@ body.hide-coords .square .coord { display: none; }
   .topbar { padding: 18px 20px; }
   .about { padding: 32px 20px 80px; }
   .about-hero { grid-template-columns: 1fr; gap: 28px; margin-bottom: 48px; }
+  .architecture-copy h3 { font-size: 32px; }
+  .flow-grid { grid-template-columns: 1fr; }
   .about-steps { grid-template-columns: 1fr; }
   .history { padding: 32px 20px 80px; }
 }

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -75,6 +75,7 @@ export default function Game() {
           onDragStart={game.onDragStart}
           onDropPiece={game.onDropPiece}
           onDragEnd={game.onDragEnd}
+          highlightedSquares={game.highlightedSquares}
         />
       </main>
 
@@ -106,11 +107,6 @@ export default function Game() {
         onPromotionClose={game.onPromotionClose}
         onPromotionPick={game.handlePromotionPick}
         playerColor={game.playerColor}
-        endgameOpen={game.endgameOpen}
-        endgameResult={game.endgameResult}
-        endgameReason={game.endgameReason}
-        onEndgameClose={game.onEndgameClose}
-        onNewGameFromEndgame={game.handleNewGameFromEndgame}
         errorOpen={game.errorOpen}
         errorMessage={game.errorMessage}
         onErrorClose={game.onErrorClose}

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -91,6 +91,39 @@ export default function Play() {
       ? game.capturedPieces.byBlack
       : game.capturedPieces.byWhite;
 
+  const statusText = (() => {
+    if (game.gameEnded) {
+      const playerWins =
+        (game.endgameResult === "1-0" && playerColor === "white") ||
+        (game.endgameResult === "0-1" && playerColor === "black");
+      const isDraw = game.endgameResult === "1/2-1/2";
+      if (isDraw) return "Draw";
+      if (playerWins) return "You win";
+      return "Gambitron wins";
+    }
+    if (game.aiThinking) return "Gambitron thinking\u2026";
+    if (game.isPlayersTurn) return "Your turn";
+    return "Gambitron\u2019s turn";
+  })();
+
+  const statusDetail = (() => {
+    if (!game.gameEnded) return "";
+    if (game.endgameReason === "checkmate") return "by checkmate";
+    if (game.endgameReason === "timeout") return "on time";
+    if (game.endgameResult === "1/2-1/2") return "stalemate or agreement";
+    return "";
+  })();
+
+  const statusColor = (() => {
+    if (!game.gameEnded) return "var(--ink-dim)";
+    const result = game.endgameResult;
+    if (result === "1/2-1/2") return "var(--ink-dim)";
+    const playerWins =
+      (result === "1-0" && playerColor === "white") ||
+      (result === "0-1" && playerColor === "black");
+    return playerWins ? "var(--accent)" : "var(--ink)";
+  })();
+
   return (
     <div className="game fade-in">
       {/* Left: board area */}
@@ -133,6 +166,7 @@ export default function Play() {
             onDragStart={game.onDragStart}
             onDropPiece={game.onDropPiece}
             onDragEnd={game.onDragEnd}
+            highlightedSquares={game.highlightedSquares}
           />
 
           {/* Color picker overlay when startOpen */}
@@ -218,6 +252,58 @@ export default function Play() {
       {/* Right rail */}
       <aside className="rail">
         <section className="card move-list-card">
+          {!game.startOpen && (
+            <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--line-soft)" }}>
+              <div
+                style={{
+                  fontFamily: "var(--serif)",
+                  fontSize: 15,
+                  lineHeight: 1.3,
+                  minHeight: "1.3em",
+                  marginBottom: 10,
+                  color: statusColor,
+                  transition: "color 600ms ease",
+                }}
+              >
+                {statusText}
+                {statusDetail && (
+                  <span
+                    style={{
+                      display: "block",
+                      fontFamily: "var(--mono)",
+                      fontSize: 10,
+                      letterSpacing: "0.14em",
+                      textTransform: "uppercase",
+                      color: "var(--ink-faint)",
+                      marginTop: 2,
+                    }}
+                  >
+                    {statusDetail}
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={game.gameEnded ? game.handleNewGameFromEndgame : game.handleNewGame}
+                style={{
+                  width: "100%",
+                  fontFamily: "var(--mono)",
+                  fontSize: 11,
+                  letterSpacing: "0.14em",
+                  textTransform: "uppercase",
+                  padding: "12px 20px",
+                  border: "1px solid",
+                  cursor: "pointer",
+                  background: game.gameEnded ? "var(--ink)" : "var(--bg-card)",
+                  color: game.gameEnded ? "#1a1a1a" : "var(--ink-dim)",
+                  borderColor: game.gameEnded ? "var(--ink)" : "var(--line)",
+                  transition: "background 1000ms ease, color 1000ms ease, border-color 1000ms ease",
+                }}
+              >
+                {game.gameEnded ? "New Game" : "Leave Game"}
+              </button>
+            </div>
+          )}
           <div className="card-head">
             <span className="title">Move list</span>
             <span
@@ -241,11 +327,6 @@ export default function Play() {
         onPromotionClose={game.onPromotionClose}
         onPromotionPick={game.handlePromotionPick}
         playerColor={game.playerColor}
-        endgameOpen={game.endgameOpen}
-        endgameResult={game.endgameResult}
-        endgameReason={game.endgameReason}
-        onEndgameClose={game.onEndgameClose}
-        onNewGameFromEndgame={game.handleNewGameFromEndgame}
         errorOpen={game.errorOpen}
         errorMessage={game.errorMessage}
         onErrorClose={game.onErrorClose}

--- a/frontend/src/utils/sounds.ts
+++ b/frontend/src/utils/sounds.ts
@@ -34,10 +34,9 @@ export function playMoveSound(): void {
 }
 
 /**
- * Plays a triumphant "checkmate" sound —
- * an ascending major arpeggio with a bright finish (you won).
+ * Plays a triumphant ascending arpeggio — you checkmated Gambitron.
  */
-export function playCheckmateSound(): void {
+export function playWinSound(): void {
   const ctx = getAudioContext();
   if (!ctx) return;
   try {
@@ -75,6 +74,52 @@ export function playCheckmateSound(): void {
     brightGain.gain.exponentialRampToValueAtTime(0.001, now + 0.80);
     bright.start(now + 0.45);
     bright.stop(now + 0.80);
+  } catch {
+    // Ignore audio errors
+  }
+}
+
+/**
+ * Plays a somber descending minor arpeggio — Gambitron checkmated you.
+ */
+export function playLossSound(): void {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  try {
+    const now = ctx.currentTime;
+
+    const notes = [
+      { freq: 523.25, start: 0.00, dur: 0.15 },
+      { freq: 440.00, start: 0.12, dur: 0.15 },
+      { freq: 349.23, start: 0.24, dur: 0.18 },
+      { freq: 261.63, start: 0.36, dur: 0.40 },
+    ];
+
+    for (const { freq, start, dur } of notes) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = "triangle";
+      osc.frequency.setValueAtTime(freq, now + start);
+      gain.gain.setValueAtTime(0, now + start);
+      gain.gain.linearRampToValueAtTime(0.13, now + start + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + start + dur);
+      osc.start(now + start);
+      osc.stop(now + start + dur + 0.01);
+    }
+
+    const low = ctx.createOscillator();
+    const lowGain = ctx.createGain();
+    low.connect(lowGain);
+    lowGain.connect(ctx.destination);
+    low.type = "sine";
+    low.frequency.setValueAtTime(82.41, now + 0.48);
+    lowGain.gain.setValueAtTime(0, now + 0.48);
+    lowGain.gain.linearRampToValueAtTime(0.16, now + 0.53);
+    lowGain.gain.exponentialRampToValueAtTime(0.001, now + 1.0);
+    low.start(now + 0.48);
+    low.stop(now + 1.0);
   } catch {
     // Ignore audio errors
   }

--- a/frontend/src/utils/sounds.ts
+++ b/frontend/src/utils/sounds.ts
@@ -32,3 +32,50 @@ export function playMoveSound(): void {
     // Ignore audio errors (e.g. autoplay policy)
   }
 }
+
+/**
+ * Plays a triumphant "checkmate" sound —
+ * an ascending major arpeggio with a bright finish (you won).
+ */
+export function playCheckmateSound(): void {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  try {
+    const now = ctx.currentTime;
+
+    const notes = [
+      { freq: 523.25, start: 0.00, dur: 0.14 },
+      { freq: 659.25, start: 0.10, dur: 0.14 },
+      { freq: 783.99, start: 0.20, dur: 0.14 },
+      { freq: 1046.50, start: 0.30, dur: 0.22 },
+    ];
+
+    for (const { freq, start, dur } of notes) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = "triangle";
+      osc.frequency.setValueAtTime(freq, now + start);
+      gain.gain.setValueAtTime(0, now + start);
+      gain.gain.linearRampToValueAtTime(0.18, now + start + 0.03);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + start + dur);
+      osc.start(now + start);
+      osc.stop(now + start + dur + 0.01);
+    }
+
+    const bright = ctx.createOscillator();
+    const brightGain = ctx.createGain();
+    bright.connect(brightGain);
+    brightGain.connect(ctx.destination);
+    bright.type = "sine";
+    bright.frequency.setValueAtTime(1318.51, now + 0.45);
+    brightGain.gain.setValueAtTime(0, now + 0.45);
+    brightGain.gain.linearRampToValueAtTime(0.12, now + 0.50);
+    brightGain.gain.exponentialRampToValueAtTime(0.001, now + 0.80);
+    bright.start(now + 0.45);
+    bright.stop(now + 0.80);
+  } catch {
+    // Ignore audio errors
+  }
+}


### PR DESCRIPTION
## Summary

- **Win/loss checkmate sounds** — triumphant ascending arpeggio when you checkmate Gambitron, somber descending arpeggio when Gambitron checkmates you
- **King square highlights** — red tint on the checkmated king, amber tint on both kings for draws
- **Removed full-screen endgame popup** — board stays fully visible; game state shown inline as status text above move list
- **Leave Game / New Game button** — above move list, shows "Leave Game" during play, smoothly transitions to white "New Game" after game ends
- **Live status text** — shows "Your turn" / "Gambitron thinking…" during game, "You win" / "Gambitron wins" / "Draw" after game ends
- **Fixed draw detection** — draws now correctly highlight both kings instead of treating them as checkmate

## Files changed
- `frontend/src/utils/sounds.ts` — added `playWinSound()` and `playLossSound()`
- `frontend/src/hooks/useGame.ts` — endgame logic, highlighted squares, win/loss sound routing
- `frontend/src/components/ChessBoard.tsx` — `highlightedSquares` prop for king highlights
- `frontend/src/components/Dialogs.tsx` — removed endgame popup
- `frontend/src/pages/Play.tsx` — status text, Leave Game/New Game button in rail
- `frontend/src/pages/Game.tsx` — `highlightedSquares` prop
- `frontend/src/index.css` — `.checkmated` (red) and `.drawn-king` (amber) square styles
- `backend/` — Python 3.9 compatibility (`from __future__ import annotations`)