### PR TITLE
feat: boost center control evaluation and add engine tournament tools

### DIFF
--- a/backend/chess_engine.py
+++ b/backend/chess_engine.py
@@ -213,7 +213,8 @@ EARLY_QUEEN_MOVE_PENALTY = 22
 EARLY_RIM_KNIGHT_PENALTY = 18
 CASTLING_READY_BONUS = 10
 CASTLED_KING_BONUS = 28
-CENTER_PAWN_OPENING_BONUS = 8
+CENTER_PAWN_OPENING_BONUS = 25
+CENTER_SQUARE_CONTROL_BONUS = 6
 MINOR_STARTING_SQUARES = {
     chess.WHITE: (
         (chess.B1, chess.KNIGHT),
@@ -368,6 +369,14 @@ def _opening_development_score(board_state: chess.Board) -> int:
             piece = board_state.piece_at(square)
             if piece and piece.color == color and piece.piece_type == chess.PAWN:
                 score += sign * CENTER_PAWN_OPENING_BONUS
+
+        center_controlled = 0
+        center_squares = (chess.D4, chess.E4, chess.D5, chess.E5)
+        friendly_pawns = board_state.pieces(chess.PAWN, color)
+        for center_sq in center_squares:
+            if board_state.attackers(color, center_sq) & friendly_pawns:
+                center_controlled += 1
+        score += sign * center_controlled * CENTER_SQUARE_CONTROL_BONUS
 
         if developed < 3:
             for square in board_state.pieces(chess.KNIGHT, color):

--- a/backend/engine_cli.py
+++ b/backend/engine_cli.py
@@ -1,0 +1,24 @@
+import sys
+import json
+
+from chess_engine import get_best_move
+
+DEPTH = 5
+TIME_LIMIT = 1.0
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            fen = line
+            result = get_best_move(fen, depth=DEPTH, time_limit=TIME_LIMIT)
+            print(json.dumps(result), flush=True)
+        except Exception as e:
+            print(json.dumps({"error": str(e)}), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/spectator.py
+++ b/backend/spectator.py
@@ -1,0 +1,175 @@
+import json
+import sys
+from pathlib import Path
+
+import chess
+import chess.svg
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+STATE_FILE = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/tmp/tournament_state.json")
+PORT = 8080
+
+MOVE_HIGHLIGHT = "#ffd70060"
+BOARD_COLORS = {"square light": "#edeed1", "square dark": "#779952"}
+
+HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Engine Tournament</title>
+<style>
+  * { box-sizing:border-box; }
+  body { background:#1a1a2e; color:#e0e0e0; font-family:system-ui; margin:0;
+         display:flex; min-height:100vh; }
+  .main { flex:1; display:flex; flex-direction:column; align-items:center;
+          padding:24px; gap:16px; }
+  .board-container { position:relative; }
+  .board-container img { max-width:540px; display:block; }
+  h1 { font-size:20px; text-align:center; margin:0; }
+  .info { text-align:center; font-size:14px; color:#888; }
+  .sidebar { width:300px; background:#16213e; border-left:1px solid #0f3460;
+             display:flex; flex-direction:column; overflow:hidden; }
+  .sidebar h2 { font-size:16px; padding:16px; margin:0; border-bottom:1px solid #0f3460; }
+  .moves { flex:1; overflow-y:auto; padding:8px; font-family:monospace; font-size:13px; }
+  .move-pair { display:flex; gap:8px; padding:2px 0; }
+  .move-num { color:#555; min-width:32px; text-align:right; }
+  .move { min-width:48px; }
+  .move.last { background:#ffd70030; border-radius:3px; padding:0 4px; }
+  .results { border-top:1px solid #0f3460; padding:16px; }
+  .results table { width:100%; border-collapse:collapse; }
+  .results td:last-child { text-align:right; font-weight:bold; }
+  .status { text-align:center; font-size:14px; padding:8px 16px;
+            border-bottom:1px solid #0f3460; }
+  .controls { padding:12px 16px; border-top:1px solid #0f3460; display:flex; gap:8px; }
+  button { background:#0f3460; color:#e0e0e0; border:none; padding:6px 12px;
+           border-radius:4px; cursor:pointer; font-size:13px; }
+  button:hover { background:#1a4a8a; }
+</style>
+</head>
+<body>
+<div class="main">
+  <h1>Engine Tournament</h1>
+  <div class="board-container" id="board"></div>
+  <div class="info" id="info"></div>
+</div>
+<div class="sidebar">
+  <div class="status" id="status">Waiting for tournament...</div>
+  <h2>Move List</h2>
+  <div class="moves" id="moves"></div>
+  <div class="results" id="results"></div>
+</div>
+<script>
+const POLL_MS = 600;
+let lastFen = "";
+
+async function poll() {
+  try {
+    const r = await fetch("/state");
+    if (!r.ok) return;
+    const s = await r.json();
+
+    // update game info
+    const infoEl = document.getElementById("info");
+    infoEl.textContent = s.game || "";
+    const statusEl = document.getElementById("status");
+    statusEl.textContent = s.game || "Waiting...";
+
+    // update board
+    if (s.fen && s.fen !== lastFen && s.board_svg) {
+      document.getElementById("board").innerHTML = s.board_svg;
+      lastFen = s.fen;
+    }
+
+    // update move list
+    if (s.move_list) {
+      const movesEl = document.getElementById("moves");
+      let html = "";
+      const lines = s.move_list;
+      for (let i = 0; i < lines.length; i += 2) {
+        const n = Math.floor(i / 2) + 1;
+        const w = lines[i] || "";
+        const b = lines[i + 1] || "";
+        html += `<div class="move-pair">
+          <span class="move-num">${n}.</span>
+          <span class="move${i === lines.length - 1 ? ' last' : ''}">${w}</span>
+          <span class="move${i + 1 === lines.length - 1 ? ' last' : ''}">${b}</span>
+        </div>`;
+      }
+      movesEl.innerHTML = html;
+      movesEl.scrollTop = movesEl.scrollHeight;
+    }
+
+    // update results
+    if (s.results) {
+      const rEl = document.getElementById("results");
+      let html = '<table>';
+      for (const [k, v] of Object.entries(s.results)) {
+        html += `<tr><td>${k}</td><td>${v}</td></tr>`;
+      }
+      html += '</table>';
+      rEl.innerHTML = html;
+    }
+  } catch(e) {}
+}
+
+setInterval(poll, POLL_MS);
+poll();
+</script>
+</body>
+</html>"""
+
+
+def _render_board(fen, highlight_squares=None):
+    if not highlight_squares:
+        highlight_squares = []
+    try:
+        board = chess.Board(fen)
+        kwargs = {"size": 520}
+        if highlight_squares:
+            kwargs["fill"] = {sq: MOVE_HIGHLIGHT for sq in highlight_squares}
+            kwargs["lastmove"] = highlight_squares[0]  # triggers python-chess arrow
+        else:
+            kwargs["lastmove"] = None
+        return chess.svg.board(board, **kwargs)
+    except Exception:
+        return '<p style="color:#888;text-align:center;">Invalid position</p>'
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/state":
+            return self._serve_state()
+        return self._serve_page()
+
+    def _serve_state(self):
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        if STATE_FILE.exists():
+            data = json.loads(STATE_FILE.read_text())
+        else:
+            data = {}
+        fen = data.get("fen", "")
+        if fen:
+            data["board_svg"] = _render_board(fen)
+        self.wfile.write(json.dumps(data).encode())
+
+    def _serve_page(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(HTML.encode())
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+def main():
+    server = HTTPServer(("", PORT), Handler)
+    print(f"Spectator ready at http://localhost:{PORT}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tournament.py
+++ b/backend/tournament.py
@@ -1,0 +1,157 @@
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import chess
+
+GAMES = 12
+DEPTH = 4
+TIME_LIMIT = 1.0
+STATE_FILE = Path("/tmp/tournament_state.json")
+
+TERMINATION_LABELS = {
+    chess.Termination.CHECKMATE: "checkmate",
+    chess.Termination.STALEMATE: "stalemate",
+    chess.Termination.INSUFFICIENT_MATERIAL: "insufficient material",
+    chess.Termination.SEVENTYFIVE_MOVES: "75-move rule",
+    chess.Termination.FIVEFOLD_REPETITION: "fivefold repetition",
+    chess.Termination.FIFTY_MOVES: "50-move rule",
+    chess.Termination.THREEFOLD_REPETITION: "threefold repetition",
+}
+
+
+def _print(*args, **kwargs):
+    kwargs.setdefault("flush", True)
+    print(*args, **kwargs)
+
+
+def _write_state(fen, game_label, move_list, results):
+    STATE_FILE.write_text(json.dumps({
+        "fen": fen,
+        "game": game_label,
+        "move_list": move_list,
+        "results": results,
+    }))
+
+
+def run_game(white_engine, black_engine, white_label, black_label, game_label, results):
+    board = chess.Board()
+    move_list = []
+    while not board.is_game_over() and len(move_list) < 200:
+        engine = white_engine if board.turn == chess.WHITE else black_engine
+        label = white_label if board.turn == chess.WHITE else black_label
+        try:
+            result = engine.get_best_move(
+                board.fen(), depth=DEPTH, time_limit=TIME_LIMIT
+            )
+        except Exception:
+            return (f"error:{label}", move_list, None)
+        if result.get("error") or result.get("san") is None:
+            return ("draw:stalemate_or_error", move_list, None)
+        chosen = chess.Move.from_uci(
+            result["from_square"] + result["to_square"]
+        )
+        move_list.append(result["san"])
+        board.push(chosen)
+        _write_state(board.fen(), game_label, move_list, results)
+
+    outcome = board.outcome()
+    if outcome is None:
+        return ("draw", move_list, None)
+    if outcome.winner == chess.WHITE:
+        return ("white", move_list, outcome.termination)
+    elif outcome.winner == chess.BLACK:
+        return ("black", move_list, outcome.termination)
+    return ("draw", move_list, outcome.termination)
+
+
+def load_engine(name, source):
+    spec = importlib.util.spec_from_file_location(name, source)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main():
+    old_source = subprocess.check_output(
+        ["git", "show", "HEAD:backend/chess_engine.py"], cwd=".."
+    )
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", prefix="old_engine_", delete=False
+    ) as f:
+        f.write(old_source.decode())
+        old_path = f.name
+
+    _print(f"Loading engines...")
+    new_engine = load_engine("chess_engine_new", "chess_engine.py")
+    old_engine = load_engine("chess_engine_old", old_path)
+    _print("Done.\n")
+
+    results = {"NEW wins": 0, "OLD wins": 0, "Draws": 0}
+    _print(f"Playing {GAMES} games — new (improved center control) vs old (baseline)")
+    _print(f"Depth={DEPTH}, Time limit={TIME_LIMIT}s per move")
+    _print(f"Spectator: http://localhost:8080")
+    _print()
+
+    for game_i in range(1, GAMES + 1):
+        start = time.perf_counter()
+
+        if game_i % 2 == 1:
+            game_label = f"Game {game_i}/{GAMES}  NEW (White) vs OLD (Black)"
+            outcome = run_game(
+                new_engine, old_engine, "new (White)", "old (Black)",
+                game_label, results,
+            )
+        else:
+            game_label = f"Game {game_i}/{GAMES}  OLD (White) vs NEW (Black)"
+            outcome = run_game(
+                old_engine, new_engine, "old (White)", "new (Black)",
+                game_label, results,
+            )
+
+        elapsed = time.perf_counter() - start
+        result_code, move_list, termination = outcome
+        num_moves = len(move_list)
+        term_label = TERMINATION_LABELS.get(termination, str(termination)) if termination else "?"
+
+        if result_code == "white" and game_i % 2 == 1:
+            results["NEW wins"] += 1
+            _print(f"Game {game_i}: NEW wins by {term_label} (White)  {num_moves // 2}P [{elapsed:.0f}s]")
+        elif result_code == "white" and game_i % 2 == 0:
+            results["OLD wins"] += 1
+            _print(f"Game {game_i}: OLD wins by {term_label} (White)  {num_moves // 2}P [{elapsed:.0f}s]")
+        elif result_code == "black" and game_i % 2 == 1:
+            results["OLD wins"] += 1
+            _print(f"Game {game_i}: OLD wins by {term_label} (Black)  {num_moves // 2}P [{elapsed:.0f}s]")
+        elif result_code == "black" and game_i % 2 == 0:
+            results["NEW wins"] += 1
+            _print(f"Game {game_i}: NEW wins by {term_label} (Black)  {num_moves // 2}P [{elapsed:.0f}s]")
+        elif result_code == "draw":
+            results["Draws"] += 1
+            _print(f"Game {game_i}: draw by {term_label}  {num_moves // 2}P [{elapsed:.0f}s]")
+        else:
+            _print(f"Game {game_i}: {outcome}  [{elapsed:.0f}s]")
+
+        _write_state("", f"Game {game_i}/{GAMES} — finished ({term_label})", move_list, results)
+
+    _print()
+    _print("=" * 50)
+    _print("RESULTS")
+    for k, v in results.items():
+        _print(f"  {k}: {v}")
+    _print("=" * 50)
+
+    os.unlink(old_path)
+    STATE_FILE.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Raised `CENTER_PAWN_OPENING_BONUS`** from 8 to 25 to increase the engine's priority on occupying the center with pawns during the opening
- **Added `CENTER_SQUARE_CONTROL_BONUS`** (6 points per controlled center square) rewarding pawns that attack d4/e4/d5/e5, encouraging the engine to fight for the center even when not directly occupying it
- **Added `tournament.py`** — head-to-head engine comparison runner that pits the current engine against any previous version (loads old code from git HEAD)
- **Added `spectator.py`** — live browser view (`http://localhost:8080`) showing board position, move list, and results during tournament play
- **Added `engine_cli.py`** — thin CLI wrapper for piping FEN strings to `get_best_move`